### PR TITLE
Structure cleanup

### DIFF
--- a/mutant/assets/deliver/deliver_artic.py
+++ b/mutant/assets/deliver/deliver_artic.py
@@ -55,8 +55,8 @@ class DeliverSC2:
 
         for sampleinfo in self.caseinfo:
             sample = sampleinfo["CG_ID_sample"]
-            region = sampleinfo["region_code"].replace(' ', '_')
-            lab = sampleinfo["lab_code"].replace(' ', '_')
+            region = sampleinfo["region_code"]
+            lab = sampleinfo["lab_code"]
 
             #rename makeConsensus
             prefix = "{0}/ncovIllumina_sequenceAnalysis_makeConsensus".format(self.indir)
@@ -201,6 +201,6 @@ class DeliverSC2:
             sumfile = os.path.join(self.indir, "{}_{}_{}_komplettering.csv".format(region, lab, self.today))
             with open(sumfile, "a") as out:
                 summary = csv.writer(out)
-                summary.writerow([record["Customer_ID_sample"], record["selection_criteria"].split(".")[1].strip())
+                summary.writerow([record["Customer_ID_sample"], record["selection_criteria"]] )
 
 

--- a/mutant/assets/run/run_artic.py
+++ b/mutant/assets/run/run_artic.py
@@ -28,7 +28,7 @@ class RunSC2:
         if outdir != "":
             resdir = outdir
         elif config != "":
-            general_config = self.get_json_data(config)
+            general_config = get_json(config)
             resdir = os.path.join(general_config["SARS-CoV-2"]["folders"]["results"], "{}_{}".format(
                 self.case, self.timestamp))
         else:
@@ -53,20 +53,3 @@ class RunSC2:
         out, err = proc.communicate()
         log.info(out)
         log.info(err)
-
-   def get_json_data(self, config):
-        if os.path.exists(config):
-            """Get sample information as json object"""
-            try:
-                with open(config) as json_file:
-                    data = json.load(json_file)
-            except Exception as e:
-                click.echo("Unable to read provided json file: {}. Exiting..".format(config))
-                click.echo(e)
-                sys.exit(-1)
-        else:
-            click.echo("Could not find supplied config: {}. Exiting..".format(config))
-            sys.exit(-1)
-        return data
-
-

--- a/mutant/cli.py
+++ b/mutant/cli.py
@@ -20,21 +20,6 @@ from mutant.assets.utils.parse import get_sarscov2_config
 WD = os.path.dirname(os.path.realpath(__file__))
 TIMESTAMP = datetime.now().strftime("%y%m%d-%H%M%S")
 
-def get_json_data(config):
-    if os.path.exists(config):
-        """Get sample information as json object"""
-        try:
-            with open(config) as json_file:
-                data = json.load(json_file)
-        except Exception as e:
-            click.echo("Unable to read provided json file: {}. Exiting..".format(config))
-            click.echo(e)
-            sys.exit(-1)
-    else:
-        click.echo("Could not find supplied config: {}. Exiting..".format(config))
-        sys.exit(-1)
-    return data
-
 @click.group()
 @click.version_option(version)
 @click.pass_context
@@ -59,7 +44,7 @@ def sarscov2(ctx, input_folder, config_artic, config_case, config_mutant, outdir
 
     # Set base for output files (Move this section)
     if config_case != "":
-        caseinfo = get_json_data(config_case)
+        caseinfo = get_sarscov2_config(config_case)
         caseID = caseinfo[0]["case_ID"]
     else:
         caseID = "artic"


### PR DESCRIPTION
### The purpose of the code changes are as follows:
-  get_json and get_sars2cov_config are segregate into separate file
- get_json calls in CLI replaced with get_sars2cov_config calls
- Something changed in the FoHM delivery file?

**How to prepare for test**:
- `cd MUTANT`
- `export PATH=$PATH:MUTANT_DIR`
- `source activate CONDA_ENV`
- `pip install .`

### How to test:
- `mutant analyse sarscov2 tests/testdata/fasta_files --profiles local,singularity --config_artic mutant/config/local/artic.json`

### Expected outcome:
- [ ] Produced files contain expected values

### Review:
- [ ] Code reviewed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
