### PR TITLE
Use fohm names in fastq dir 

### DIFF
--- a/mutant/assets/deliver/deliver_artic.py
+++ b/mutant/assets/deliver/deliver_artic.py
@@ -257,7 +257,7 @@ class DeliverSC2:
                     "format": "bam",
                     "id": sampleID,
                     "path": "{}/ncovIllumina_sequenceAnalysis_readMapping/{}.sorted.bam".format(
-                        self.indir, sample
+                        self.indir, base_sample
                     ),
                     "path_index": "~",
                     "step": "alignment",


### PR DESCRIPTION
### The purpose of the code changes are as follows:
-  Renamed input files in CG to function better. Thus the rename functions in MUTANT are now legacy since names are just derived from the base one.

**How to prepare for test**:
- `cd MUTANT`
- `export PATH=$PATH:MUTANT_DIR`
- `source activate CONDA_ENV`
- `pip install .`

### How to test:
- `mutant analyse sarscov2 tests/testdata/fasta_files --profiles local,singularity --config_artic mutant/config/local/artic.json`

### Expected outcome:
- [x] Produced files contain expected values

### Review:
- [x] Code reviewed by @Mropat @sylvinite 

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
