### PR TITLE
fix name parsing

### DIFF
--- a/mutant/postproc/deliver_artic.py
+++ b/mutant/postproc/deliver_artic.py
@@ -69,13 +69,13 @@ class DeliverSC2:
 
             # rename makeConsensus
             prefix = "{0}/ncovIllumina_sequenceAnalysis_makeConsensus".format(self.indir)
-            for item in glob.glob("{0}/{1}*".format(prefix, base_sample)):
+            for item in glob.glob("{0}/{1}.*".format(prefix, base_sample)):
                 newpath = "{0}/{1}.consensus.fasta".format(prefix, base_sample)
                 os.symlink(item, newpath)
 
             # rename typeVariants
             prefix = "{0}/ncovIllumina_Genotyping_typeVariants/vcf".format(self.indir)
-            for item in glob.glob("{0}/{1}*.csq.vcf".format(prefix, base_sample)):
+            for item in glob.glob("{0}/{1}.csq.vcf".format(prefix, base_sample)):
                 newpath = "{0}/{1}.vcf".format(prefix, base_sample)
                 os.symlink(item, newpath)
 


### PR DESCRIPTION
### The purpose of the code changes are as follows:
Resolve bug with naming wildcard when finishing mutant analysis
```
Running command source activate P_mutant; /home/proj/bin/conda/envs/P_mutant/bin/mutant analyse sarscov2 --config_case /home/proj/production/mutant/cases/securepig/case_config.json --outdir /home/proj/production/mutant/cases/securepig/results /home/proj/production/mutant/cases/securepig/fastq
Call ['source activate P_mutant;', '/home/proj/bin/conda/envs/P_mutant/bin/mutant', 'analyse', 'sarscov2', '--config_case', '/home/proj/production/mutant/cases/securepig/case_config.json', '--outdir', '/home/proj/production/mutant/cases/securepig/results', '/home/proj/production/mutant/cases/securepig/fastq'] exit with a non zero exit code
[2021-04-17 14:11:50,203] - DEBUG: Command ran: nextflow -C /home/proj/production/mutant/MUTANT/mutant/config/hasta/artic.json -log /home/proj/production/mutant/cases/securepig/results/nextflow.log run -work-dir /home/proj/production/mutant/cases/securepig/results/work /home/proj/production/mutant/MUTANT/mutant/externals/gms-artic/main.nf -profile singularity,slurm --illumina --prefix securepig_210417-141150 --directory /home/proj/production/mutant/cases/securepig/fastq --outdir /home/proj/production/mutant/cases/securepig/results
[2021-04-17 14:20:01,610] - INFO: None
[2021-04-17 14:20:01,610] - INFO: None
Traceback (most recent call last):
  File "/home/proj/bin/conda/envs/P_mutant/bin/mutant", line 33, in <module>
    sys.exit(load_entry_point('mutant', 'console_scripts', 'mutant')())
  File "/home/proj/bin/conda/envs/P_mutant/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/proj/bin/conda/envs/P_mutant/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/proj/bin/conda/envs/P_mutant/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/proj/bin/conda/envs/P_mutant/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/proj/bin/conda/envs/P_mutant/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/proj/bin/conda/envs/P_mutant/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/proj/bin/conda/envs/P_mutant/lib/python3.7/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/proj/production/mutant/MUTANT/mutant/cli.py", line 85, in sarscov2
    delivery.rename_deliverables()
  File "/home/proj/production/mutant/MUTANT/mutant/postproc/deliver_artic.py", line 74, in rename_deliverables
    os.symlink(item, newpath)
FileExistsError: [Errno 17] File exists: '/home/proj/production/mutant/cases/securepig/results/ncovIllumina_sequenceAnalysis_makeConsensus/01_Region_Stockholm_SE100_Karolinska_CORONANEG1.primertrimmed.consensus.fa' -> '/home/proj/production/mutant/cases/securepig/results/ncovIllumina_sequenceAnalysis_makeConsensus/01_Region_Stockholm_SE100_Karolinska_CORONANEG.consensus.fasta'

```

**How to prepare for test**:
- `cd MUTANT`
- `export PATH=$PATH:MUTANT_DIR`
- `source activate CONDA_ENV`
- `pip install -e .`

### How to test:
- `mutant analyse sarscov2 tests/testdata/fasta_files --profiles local,singularity --config_artic mutant/config/local/artic.json --config_mutant mutant/config/local/mutant.json`

### Expected outcome:
- [x] Produced files contain expected values

### Review:
- [x] Code reviewed by @sylvinite 

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
