### PR TITLE
Removed tags that is concatenated by cg in another step

### DIFF
--- a/mutant/standalone/concatenate.py
+++ b/mutant/standalone/concatenate.py
@@ -22,7 +22,7 @@ base_path = sys.argv[1]
 if len(sys.argv) == 3:
     app_tag = sys.argv[2]
 
-    PREFIX_TO_CONCATENATE = ["MWG", "MWL", "MWM", "MWR", "MWX", "VWG", "VWL", "VWM"]
+    PREFIX_TO_CONCATENATE = ["MWG", "MWL", "MWM", "MWR", "MWX"]
     should_concatenate = False
 
     for prefix in PREFIX_TO_CONCATENATE:


### PR DESCRIPTION
### The purpose of the code changes are as follows:
The VW-app tags should not be concatenated, these tags are already concatenated by cg.

**How to prepare for test**:
- `cd MUTANT`
- `export PATH=$PATH:MUTANT_DIR`
- `source activate CONDA_ENV`
- `pip install -e .`

### How to test:
- `mutant analyse sarscov2 tests/testdata/fasta_files --profiles local,singularity --config_artic mutant/config/local/artic.json --config_mutant mutant/config/local/mutant.json`

### Expected outcome:
- [ ] Produced files contain expected values

### Review:
- [ ] Code reviewed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
