### PR TITLE
Fixed error when folder is empty

### DIFF
--- a/mutant/standalone/concatenate.py
+++ b/mutant/standalone/concatenate.py
@@ -35,10 +35,16 @@ if len(sys.argv) == 3:
         sys.exit(-1)
 
 for dir_name in os.listdir(base_path):
+    dir_path = os.path.join(base_path, dir_name)
+    if len(os.listdir(dir_path)) == 0:
+        print("Empty folder found: %s" % (dir_path))
+        cmd = "rmdir " + str(dir_path)
+        os.system(cmd)
+        print("Running command: %s" % (cmd))
+        continue
+    if not os.path.isdir(dir_path):
+        continue
     for read_direction in [1, 2]:
-        dir_path = os.path.join(base_path, dir_name)
-        if not os.path.isdir(dir_path):
-            continue
         same_direction = []
         total_size = 0
         for file in os.listdir(dir_path):


### PR DESCRIPTION
### The purpose of the code changes are as follows:
Before the concatenation crashed if one folder was empty. It is possible that folders are empty so this situation should be handled

**How to prepare for test**:
- `cd MUTANT`
- `export PATH=$PATH:MUTANT_DIR`
- `source activate CONDA_ENV`
- `pip install -e .`

### How to test:
- `mutant analyse sarscov2 tests/testdata/fasta_files --profiles local,singularity --config_artic mutant/config/local/artic.json --config_mutant mutant/config/local/mutant.json`

### Expected outcome:
- [ ] Produced files contain expected values

### Review:
- [ ] Code reviewed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
