### PR TITLE
Fixed logic error

### DIFF
--- a/mutant/standalone/concatenate.py
+++ b/mutant/standalone/concatenate.py
@@ -41,12 +41,16 @@ parser.add_argument("-d",
                     default="")
 
 args = parser.parse_args()
+should_concatenate = False
 
-if args.app_tag not in PREFIX_TO_CONCATENATE:
+for prefix in PREFIX_TO_CONCATENATE:
+    if args.app_tag.startswith(prefix):
+        print("Apptag %s identified, data generated with this application tag should be concatenated" % (args.app_tag))
+        should_concatenate = True
+
+if should_concatenate == False:
     print("Data with application tag %s should not be concatenated, skipping concatenation" % (args.app_tag))
     sys.exit(-1)
-else:
-    print("Apptag %s identified, data generated with this application tag should be concatenated" % (args.app_tag))
 
 for dir_name in os.listdir(args.input_folder):
     dir_path = os.path.join(args.input_folder, dir_name)


### PR DESCRIPTION
### The purpose of the code changes are as follows:
-  Fixes a logic error when reading the app tag that prevented concatenation from starting

**How to prepare for test**:
- `cd MUTANT`
- `export PATH=$PATH:MUTANT_DIR`
- `source activate CONDA_ENV`
- `pip install -e .`

### How to test:
- `mutant analyse sarscov2 tests/testdata/fasta_files --profiles local,singularity --config_artic mutant/config/local/artic.json --config_mutant mutant/config/local/mutant.json --config_case tests/testdata/MIC3109_artic.json`

### Expected outcome:
- [x] Concatenation starts when using a mikro apptag

### Review:
- [x] Code reviewed by @sylvinite 

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
