### PR TITLE
KS report & FoHM delivery changes

### DIFF
--- a/mutant/config/hasta/artic-prod.json
+++ b/mutant/config/hasta/artic-prod.json
@@ -4,7 +4,7 @@ profiles {
         process.executor = 'slurm'
         process.clusterOptions = { "-A production --qos high" }
         process.time = '1h'
-        process.memory = '8 GB'
+        process.memory = '16 GB'
         process.cpus = 4
     }
 }
@@ -13,7 +13,7 @@ process {
         cpus = 6
     }
     withLabel: largemem {
-        memory = '24 GB'
+        memory = '48 GB'
     }
 }
 

--- a/mutant/config/hasta/artic-stage.json
+++ b/mutant/config/hasta/artic-stage.json
@@ -4,7 +4,7 @@ profiles {
         process.executor = 'slurm'
         process.clusterOptions = { "-A development --qos low" }
         process.time = '1h'
-        process.memory = '8 GB'
+        process.memory = '16 GB'
         process.cpus = 4
     }
 }
@@ -13,7 +13,7 @@ process {
         cpus = 6
     }
     withLabel: largemem {
-        memory = '24 GB'
+        memory = '48 GB'
     }
 }
 

--- a/mutant/config/hasta/artic.json
+++ b/mutant/config/hasta/artic.json
@@ -4,7 +4,7 @@ profiles {
         process.executor = 'slurm'
         process.clusterOptions = { "-A production --qos high" }
         process.time = '1h'
-        process.memory = '8 GB'
+        process.memory = '16 GB'
         process.cpus = 4
     }
 }
@@ -13,7 +13,7 @@ process {
         cpus = 6
     }
     withLabel: largemem {
-        memory = '24 GB'
+        memory = '48 GB'
     }
 }
 

--- a/mutant/modules/sarscov2_report.py
+++ b/mutant/modules/sarscov2_report.py
@@ -187,16 +187,19 @@ class ReportSC2:
                 ]
             )
             for sample, data in self.articdata.items():
-                n_bases = 10x_bases = "0.0"
+                n_bases = tenx_bases = "0.0"
                 qc_status = "FALSE"
                 lineage = "None"
                 version = "1970-01-01" 
-                vocs = vocs_aa = '-'
+                vocs = vocs_aa = "-"
+                selection = "-"
 
+                if 'selection_criteria' in data:
+                    selection = data['selection_criteria']
                 if 'pct_n_bases' in data:
                     n_bases = data['pct_n_bases']
                 if 'pct_10x_bases' in data:
-                    10x_bases = data['pct_10x_bases']
+                    tenx_bases = data['pct_10x_bases']
                 if 'qc' in data:
                     qc_status = data['qc']
                 if 'lineage' in data:
@@ -213,7 +216,7 @@ class ReportSC2:
                     selection,
                     ticket,
                     n_bases,
-                    10x_bases,
+                    tenx_bases,
                     qc_status,
                     lineage,
                     version,
@@ -432,7 +435,7 @@ class ReportSC2:
                 "path": "{}/instrument.properties".format(self.indir),
                 "path_index": "~",
                 "step": "report",
-                "tag": "instrument-properties","fohm-delivery",
+                "tag": ["instrument-properties","fohm-delivery"],
             }
         )
 

--- a/mutant/modules/sarscov2_report.py
+++ b/mutant/modules/sarscov2_report.py
@@ -303,9 +303,6 @@ class ReportSC2:
         voc_strains['spike'] = classifications['spike'].tolist()
         voc_strains['class'] = classifications['class'].tolist()
 
-        #voc_pos_aa = get_json("{0}/standalone/voc_strains.json".format(WD))['voc_pos_aa']
-        #voc_strains = get_json("{0}/standalone/voc_strains.json".format(WD))['voc_strains']
-
         artic_data = dict()
         var_all = dict()
         var_voc = dict()
@@ -362,9 +359,9 @@ class ReportSC2:
                 artic_data[sample].update(
                     {
                         "lineage": lineage,
-                        "pangolin_probability": line[2],
-                        "pangoLEARN_version": line[3],
-                        "pangolin_qc": line[4],
+                        "pangolin_probability": line[3],
+                        "pangoLEARN_version": line[-4],
+                        "pangolin_qc": line[-2],
                     }
                 )
 
@@ -413,9 +410,11 @@ class ReportSC2:
                 artic_data[key].update( {"VOC":"-"})
             elif artic_data[key]["lineage"] in voc_strains['lineage']:
                 index = voc_strains['lineage'].index(artic_data[key]['lineage'])
+                if voc_strains['class'][index] == "VOC":
+                    artic_data[key].update( {"VOC":"Yes"})
                 #Check for spike
-                if pandas.isna(voc_strains['spike'][index]) or voc_strains['spike'][index] in artic_data[key]['VOC_aa']:
-                    artic_data[key].update( {"VOC":voc_strains['class'][index]} )
+                #if pandas.isna(voc_strains['spike'][index]) or voc_strains['spike'][index] in artic_data[key]['VOC_aa']:
+                    #artic_data[key].update( {"VOC":voc_strains['class'][index]} )
 
 
 

--- a/mutant/modules/sarscov2_report.py
+++ b/mutant/modules/sarscov2_report.py
@@ -590,17 +590,17 @@ class ReportSC2:
         for regionlab in self.regionlabs:
             rl = regionlab
             # Region split Pangolin typing
-            deliv["files"].append(
-                {
-                    "format": "csv",
-                    "id": self.case,
-                    "path": "{}/ncovIllumina_sequenceAnalysis_makeConsensus/"
-                    "{}_{}_pangolin_classification.txt".format(self.indir, rl, self.today),
-                    "path_index": "~",
-                    "step": "typing",
-                    "tag": "SARS-CoV-2-type",
-                }
-            )
+            #deliv["files"].append(
+            #    {
+            #        "format": "csv",
+            #        "id": self.case,
+            #        "path": "{}/ncovIllumina_sequenceAnalysis_makeConsensus/"
+            #        "{}_{}_pangolin_classification.txt".format(self.indir, rl, self.today),
+            #        "path_index": "~",
+            #        "step": "typing",
+            #        "tag": "SARS-CoV-2-type",
+            #    }
+            #)
 
             # Region split FoHM delivery file
             deliv["files"].append(

--- a/mutant/modules/sarscov2_report.py
+++ b/mutant/modules/sarscov2_report.py
@@ -190,7 +190,7 @@ class ReportSC2:
                 n_bases = tenx_bases = "0.0"
                 qc_status = "FALSE"
                 lineage = "None"
-                version = "1970-01-01" 
+                verzion = "1970-01-01" 
                 vocs = vocs_aa = "-"
                 selection = "-"
 
@@ -204,8 +204,8 @@ class ReportSC2:
                     qc_status = data['qc']
                 if 'lineage' in data:
                     lineage = data['lineage']
-                if 'pangoLEARN_version' in data:
-                    version = data['pangoLEARN_version']
+                if 'pangoLEARN_version' in data and data["pangoLEARN_version"] != "":
+                    verzion = data['pangoLEARN_version']
                 if 'VOC' in data:
                     vocs = data['VOC']
                 if "VOC_aa" in data:
@@ -219,7 +219,7 @@ class ReportSC2:
                     tenx_bases,
                     qc_status,
                     lineage,
-                    version,
+                    verzion,
                     vocs,
                     vocs_aa
                 ]

--- a/mutant/modules/sarscov2_report.py
+++ b/mutant/modules/sarscov2_report.py
@@ -44,12 +44,13 @@ class ReportSC2:
         self.articdata = dict()
 
     def create_all_files(self):
+        self.load_lookup_dict()
+
         self.create_trailblazer_config()
         self.create_concat_pangolin()
         self.create_concat_consensus()
         self.create_deliveryfile()
         self.create_fohm_csv()
-        self.load_lookup_dict()
         self.create_sarscov2_resultfile()
         self.create_sarscov2_variantfile()
         self.create_jsonfile()
@@ -198,8 +199,8 @@ class ReportSC2:
                     selection = data['selection_criteria']
                 if 'pct_n_bases' in data:
                     n_bases = data['pct_n_bases']
-                if 'pct_10x_bases' in data:
-                    tenx_bases = data['pct_10x_bases']
+                if 'pct_10X_bases' in data:
+                    tenx_bases = data['pct_10X_bases']
                 if 'qc' in data:
                     qc_status = data['qc']
                 if 'lineage' in data:

--- a/mutant/modules/sarscov2_report.py
+++ b/mutant/modules/sarscov2_report.py
@@ -435,7 +435,7 @@ class ReportSC2:
                 "path": "{}/instrument.properties".format(self.indir),
                 "path_index": "~",
                 "step": "report",
-                "tag": ["instrument-properties","fohm-delivery"],
+                "tag": "instrument-properties",
             }
         )
 

--- a/mutant/modules/sarscov2_report.py
+++ b/mutant/modules/sarscov2_report.py
@@ -277,14 +277,16 @@ class ReportSC2:
 
         packing = dict(zip(casekeys, "-"*len(casekeys)))
 
-        #Packs with keys. Time consuming but not really
+        #Updates existing samples with defaults for case-config
         for k, v in self.articdata.items():
             self.articdata[k].update(packing)
-        #Writes caseconfig data where relevant
+        #Updates existing samples with provided case-config info
         for entry in self.caseinfo:
             k = entry['Customer_ID_sample']
             if k in self.articdata.keys():
                 self.articdata[k].update(entry)
+            else:
+                self.articdata[k] = entry
 
 
     def load_artic_results(self):

--- a/mutant/modules/sarscov2_report.py
+++ b/mutant/modules/sarscov2_report.py
@@ -130,7 +130,7 @@ class ReportSC2:
 
 
     def create_instrument_properties(self):
-        """Creates a summary file for FoHM for each region-lab-combination"""
+        """Creates a properties file with instrument information"""
 
         propfile = os.path.join(
             self.indir,"instrument.properties")

--- a/mutant/modules/sarscov2_report.py
+++ b/mutant/modules/sarscov2_report.py
@@ -168,10 +168,10 @@ class ReportSC2:
         indir = self.indir
 
         summaryfile = os.path.join(
-            indir, "sars-cov-2_{}_results.csv".format(ticket, today)
-        )
+            indir, "sars-cov-2_{}_results.csv".format(ticket))
         with open(summaryfile, mode="w") as out:
             summary = csv.writer(out)
+            #Backrolled Mutations to Variants
             summary.writerow(
                 [
                     "Sample",
@@ -183,53 +183,44 @@ class ReportSC2:
                     "Lineage",
                     "PangoLEARN_version",
                     "VOC",
+                    "Variants",
                 ]
             )
             for sample, data in self.articdata.items():
-                selection = "-"
+                n_bases = 10x_bases = "0.0"
+                qc_status = "FALSE"
+                lineage = "None"
+                version = "1970-01-01" 
+                vocs = vocs_aa = '-'
+
+                if 'pct_n_bases' in data:
+                    n_bases = data['pct_n_bases']
+                if 'pct_10x_bases' in data:
+                    10x_bases = data['pct_10x_bases']
+                if 'qc' in data:
+                    qc_status = data['qc']
+                if 'lineage' in data:
+                    lineage = data['lineage']
+                if 'pangoLEARN_version' in data:
+                    version = data['pangoLEARN_version']
+                if 'VOC' in data:
+                    vocs = data['VOC']
+                if "VOC_aa" in data:
+                    vocs_aa = data['VOC_aa']
+
                 row = [
                     sample,
-                    data["selection_criteria"],
+                    selection,
                     ticket,
-                    data["pct_n_bases"],
-                    data["pct_10X_bases"],
-                    data["qc"],
-                    data["lineage"],
-                    data["pangoLEARN_version"],
-                    data["VOC"],
+                    n_bases,
+                    10x_bases,
+                    qc_status,
+                    lineage,
+                    version,
+                    vocs,
+                    vocs_aa
                 ]
-#        with open(summaryfile, mode="w") as out:
-#            summary = csv.writer(out)
-#            summary.writerow(
-#                [
-#                    "Sample",
-#                    "Selection",
-#                    "Region Code",
-#                    "Ticket",
-#                    "%N_bases",
-#                    "%10X_coverage",
-#                    "QC_pass",
-#                    "Lineage",
-#                    "PangoLEARN_version",
-#                    "VOC",
-#                    "Mutations",
-#                ]
-#            )
-#            for sample, data in self.articdata.items():
-#                selection = "-"
-#                row = [
-#                    sample,
-#                    data["selection_criteria"],
-#                    data["region_code"],
-#                    ticket,
-#                    data["pct_n_bases"],
-#                    data["pct_10X_bases"],
-#                    data["qc"],
-#                    data["lineage"],
-#                    data["pangoLEARN_version"],
-#                    data["VOC"],
-#                    data["VOC_aa"],
-#                ]
+
                 summary.writerow(row)
 
     def create_sarscov2_variantfile(self):

--- a/mutant/modules/sarscov2_report.py
+++ b/mutant/modules/sarscov2_report.py
@@ -147,7 +147,6 @@ class ReportSC2:
                 [
                     "Sample",
                     "Selection",
-                    "Region Code",
                     "Ticket",
                     "%N_bases",
                     "%10X_coverage",
@@ -155,8 +154,6 @@ class ReportSC2:
                     "Lineage",
                     "PangoLEARN_version",
                     "VOC",
-                    "Mutations",
-
                 ]
             )
             for sample, data in self.articdata.items():
@@ -164,7 +161,6 @@ class ReportSC2:
                 row = [
                     sample,
                     data["selection_criteria"],
-                    data["region_code"],
                     ticket,
                     data["pct_n_bases"],
                     data["pct_10X_bases"],
@@ -172,9 +168,39 @@ class ReportSC2:
                     data["lineage"],
                     data["pangoLEARN_version"],
                     data["VOC"],
-                    data["VOC_aa"],
-
                 ]
+#        with open(summaryfile, mode="w") as out:
+#            summary = csv.writer(out)
+#            summary.writerow(
+#                [
+#                    "Sample",
+#                    "Selection",
+#                    "Region Code",
+#                    "Ticket",
+#                    "%N_bases",
+#                    "%10X_coverage",
+#                    "QC_pass",
+#                    "Lineage",
+#                    "PangoLEARN_version",
+#                    "VOC",
+#                    "Mutations",
+#                ]
+#            )
+#            for sample, data in self.articdata.items():
+#                selection = "-"
+#                row = [
+#                    sample,
+#                    data["selection_criteria"],
+#                    data["region_code"],
+#                    ticket,
+#                    data["pct_n_bases"],
+#                    data["pct_10X_bases"],
+#                    data["qc"],
+#                    data["lineage"],
+#                    data["pangoLEARN_version"],
+#                    data["VOC"],
+#                    data["VOC_aa"],
+#                ]
                 summary.writerow(row)
 
     def create_sarscov2_variantfile(self):

--- a/mutant/modules/sarscov2_report.py
+++ b/mutant/modules/sarscov2_report.py
@@ -563,9 +563,7 @@ class ReportSC2:
 #                    "format": "csv",
 #                    "id": self.case,
 #                    "path": "{}/ncovIllumina_sequenceAnalysis_makeConsensus/"
-#                    "{}_{}_pangolin_classification.txt".format(
-#                        self.indir, rl, self.today
-#                    ),
+#                    "{}_{}_pangolin_classification.txt".format(self.indir, rl),
 #                    "path_index": "~",
 #                    "step": "typing",
 #                    "tag": "SARS-CoV-2-type",


### PR DESCRIPTION
### The purpose of the code changes are as follows:
-  Backrolled KS reports Region code and Mutations
- Added support for negative samples in KS report
- Readded vcf files to deliveryfile under vcf-covid
- Defined and added instruments.properties file

### Preparations:

**How to prepare mutant for test**:
* `bash mutant/standalone/deploy_hasta_update.sh stage <MUTANT_branch>`

**How to prepare cg for test**:
- `us`
- Paxa and update cg or other tools needed for the test:
  - `paxa -u <user> -s hasta -r cg-stage`
  - `paxa -u <user> -s hasta -r servers-stage`
  - `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh master`
  - `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-servers-stage.sh master`
  

### How to test:
Run in a tmux screen or similar if testing on a large dataset.

**Test with cg**:
- `us`
- `cg workflow mutant start maturejay (trustywalrus)`

### Expected outcome:
- [x] Produced files contain expected values

### Review:
- [x] Code reviewed by @talnor 
- [x] KS format accepted by KS
- [x] Hermes code changes created/accepted https://github.com/Clinical-Genomics/hermes/pull/28
- [x] KS report file contain QC fail samples
- [x] vcf-covid files in delivery
- [x] instrument.properties in results

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
