### PR TITLE
Update sars-cov-2 report

### DIFF
--- a/mutant/__init__.py
+++ b/mutant/__init__.py
@@ -9,7 +9,6 @@ WD = os.path.dirname(os.path.realpath(__file__))
 TIMESTAMP = datetime.now().strftime("%y%m%d-%H%M%S")
 
 
-
 # Initialize log
 log = logging.getLogger("main_log")
 log.setLevel(logging.DEBUG)

--- a/mutant/cli.py
+++ b/mutant/cli.py
@@ -15,6 +15,7 @@ from mutant.modules.generic_parser import get_json
 from mutant.modules.sarscov2_report import ReportSC2
 from mutant.modules.sarscov2_delivery import DeliverySC2
 
+
 @click.group()
 @click.version_option(version)
 @click.pass_context
@@ -62,7 +63,6 @@ def sarscov2(
     else:
         caseID = "artic"
     prefix = "{}_{}".format(caseID, TIMESTAMP)
-
 
     # Run
     run = RunSC2(
@@ -130,7 +130,6 @@ def sarscov2(ctx):
 def postproc(ctx, input_folder, config_artic, fastq_folder, config_case):
     """Applies all cg post-processing of the sarscov2 pipeline"""
 
-
     # Reports
     if config_case != "":
         report = ReportSC2(
@@ -176,15 +175,26 @@ def rename(ctx, input_folder, config_artic, config_case):
 
 @toolbox.command()
 @click.option("--input_folder", help="Folder with fastq to concatenate", required=True)
-@click.option("--app_tag", help="Application tag", required=False, default="CONCATENATE")
-@click.option("--date", help="Date to add to the concatenated file name, e.g. order date", required=False, default=None)
+@click.option(
+    "--app_tag", help="Application tag", required=False, default="CONCATENATE"
+)
+@click.option(
+    "--date",
+    help="Date to add to the concatenated file name, e.g. order date",
+    required=False,
+    default=None,
+)
 @click.pass_context
 def concatenate(ctx, input_folder, app_tag, date):
-    """ Concatenates fastq files if needed """
+    """Concatenates fastq files if needed"""
     if date:
-        cmd = "python {0}/standalone/concatenate.py --input_folder {1} --app_tag {2} --date {3}".format(WD, input_folder, app_tag, date)
+        cmd = "python {0}/standalone/concatenate.py --input_folder {1} --app_tag {2} --date {3}".format(
+            WD, input_folder, app_tag, date
+        )
     else:
-        cmd = "python {0}/standalone/concatenate.py --input_folder {1} --app_tag {2}".format(WD, input_folder, app_tag)
+        cmd = "python {0}/standalone/concatenate.py --input_folder {1} --app_tag {2}".format(
+            WD, input_folder, app_tag
+        )
     log.debug("Command ran: {}".format(cmd))
     proc = subprocess.Popen(cmd.split())
     out, err = proc.communicate()

--- a/mutant/modules/sarscov2_delivery.py
+++ b/mutant/modules/sarscov2_delivery.py
@@ -21,8 +21,6 @@ class DeliverySC2:
         self.project = caseinfo[0]["Customer_ID_project"]
         self.indir = indir
 
-
-
     def rename_deliverables(self):
         """Rename result files for delivery: fastq, consensus files, vcf and pangolin"""
 
@@ -47,7 +45,9 @@ class DeliverySC2:
                 try:
                     with open(item, "r") as old_consensus_io:
                         with open(newpath, "w") as new_consensus_io:
-                            new_consensus_io.write(f">{base_sample}\n{old_consensus_io.readlines()[1]}")
+                            new_consensus_io.write(
+                                f">{base_sample}\n{old_consensus_io.readlines()[1]}"
+                            )
 
                 except Exception as e:
                     print(e)
@@ -65,7 +65,11 @@ class DeliverySC2:
         ## Rename case files
 
         # rename multiqc
-        hit = glob.glob("{}/QCStats/ncovIllumina_sequenceAnalysis_multiqc/*_multiqc.html".format(self.indir))
+        hit = glob.glob(
+            "{}/QCStats/ncovIllumina_sequenceAnalysis_multiqc/*_multiqc.html".format(
+                self.indir
+            )
+        )
         if len(hit) == 1:
             hit = hit[0]
             try:
@@ -75,7 +79,9 @@ class DeliverySC2:
 
         # rename multiqc json
         hit = glob.glob(
-            "{}/QCStats/ncovIllumina_sequenceAnalysis_multiqc/*_multiqc_data/multiqc_data.json".format(self.indir)
+            "{}/QCStats/ncovIllumina_sequenceAnalysis_multiqc/*_multiqc_data/multiqc_data.json".format(
+                self.indir
+            )
         )
         if len(hit) == 1:
             hit = hit[0]

--- a/mutant/modules/sarscov2_report.py
+++ b/mutant/modules/sarscov2_report.py
@@ -197,7 +197,6 @@ class ReportSC2:
         summaryfile = os.path.join(indir, "sars-cov-2_{}_results.csv".format(ticket))
         with open(summaryfile, mode="w") as out:
             summary = csv.writer(out)
-            # Backrolled Mutations to Variants
             summary.writerow(
                 [
                     "Sample",
@@ -210,7 +209,7 @@ class ReportSC2:
                     "Lineage",
                     "PangoLEARN_version",
                     "VOC",
-                    "Variants",
+                    "Mutations",
                 ]
             )
             for sample, data in self.articdata.items():

--- a/mutant/modules/sarscov2_report.py
+++ b/mutant/modules/sarscov2_report.py
@@ -418,20 +418,19 @@ class ReportSC2:
                     artic_data[sample].update({"variants": "-"})
 
         # Classification
-        for key, vals in artic_data.items():
+        for sample, vals in artic_data.items():
             # Packing
-            artic_data[key].update({"VOC": "No"})
+            artic_data[sample].update({"VOC": "No"})
 
             # Check for lineage
-            if artic_data[key]["lineage"] == "None":
-                artic_data[key].update({"VOC": "-"})
-            elif artic_data[key]["lineage"] in voc_strains["lineage"]:
-                index = voc_strains["lineage"].index(artic_data[key]["lineage"])
-                if voc_strains["class"][index] == "VOC":
-                    artic_data[key].update({"VOC": "Yes"})
+            if artic_data[sample]["lineage"] == "None":
+                artic_data[sample].update({"VOC": "-"})
+            elif artic_data[sample]["lineage"] in voc_strains["lineage"]:
+                index = voc_strains["lineage"].index(artic_data[sample]["lineage"])
                 # Check for spike
-                # if pandas.isna(voc_strains['spike'][index]) or voc_strains['spike'][index] in artic_data[key]['VOC_aa']:
-                # artic_data[key].update( {"VOC":voc_strains['class'][index]} )
+                if pandas.isna(voc_strains["spike"][index]) or voc_strains["spike"][index] in artic_data[sample]["variants"]:
+                    # Add variant class
+                    artic_data[sample].update( {"VOC":voc_strains["class"][index]} )
 
         self.articdata.update(artic_data)
 

--- a/mutant/modules/sarscov2_report.py
+++ b/mutant/modules/sarscov2_report.py
@@ -202,6 +202,7 @@ class ReportSC2:
                 [
                     "Sample",
                     "Selection",
+                    "Region Code",
                     "Ticket",
                     "%N_bases",
                     "%10X_coverage",
@@ -222,6 +223,8 @@ class ReportSC2:
 
                 if "selection_criteria" in data:
                     selection = data["selection_criteria"]
+                if "region_code" in data:
+                    region = data["region_code"]
                 if "pct_n_bases" in data:
                     n_bases = data["pct_n_bases"]
                 if "pct_10X_bases" in data:
@@ -240,6 +243,7 @@ class ReportSC2:
                 row = [
                     sample,
                     selection,
+                    region,
                     ticket,
                     n_bases,
                     tenx_bases,

--- a/mutant/modules/sarscov2_report.py
+++ b/mutant/modules/sarscov2_report.py
@@ -96,7 +96,9 @@ class ReportSC2:
                     taxon_regex = "(\w+)_(\w+)_(\w+)_(?P<name>\w+).(\S+)"
                     sample, subs = re.subn(taxon_regex, r"\g<name>", line.split(",")[0])
                     if subs == 0:
-                        print("Unable to rename taxon - using original: {}".format(pango))
+                        print(
+                            "Unable to rename taxon - using original: {}".format(pango)
+                        )
                     else:
                         line = sample + line[line.find(",") :]
                     concat.write(line)
@@ -286,7 +288,9 @@ class ReportSC2:
             print("No artic results loaded. Quitting create_jsonfile")
             sys.exit(-1)
 
-        with open("{}/{}_artic.json".format(self.indir, self.ticket, self.today), "w") as outfile:
+        with open(
+            "{}/{}_artic.json".format(self.indir, self.ticket, self.today), "w"
+        ) as outfile:
             json.dump(self.articdata, outfile)
 
     def load_lookup_dict(self):
@@ -319,7 +323,9 @@ class ReportSC2:
         # Magical unpacking into single list
         voc_pos_aa = sum(muts.values.tolist(), [])
 
-        classifications = pandas.read_csv("{0}/standalone/classifications.csv".format(WD), sep=",")
+        classifications = pandas.read_csv(
+            "{0}/standalone/classifications.csv".format(WD), sep=","
+        )
         voc_strains = {"lineage": "", "spike": "", "class": ""}
         voc_strains["lineage"] = classifications["lineage"].tolist()
         voc_strains["spike"] = classifications["spike"].tolist()
@@ -341,7 +347,11 @@ class ReportSC2:
                 if len(hits) == 0:
                     raise Exception("File not found")
                 if len(hits) > 1:
-                    print("Multiple hits for {0}/{1}, picking {2}".format(indir, f, hits[0]))
+                    print(
+                        "Multiple hits for {0}/{1}, picking {2}".format(
+                            indir, f, hits[0]
+                        )
+                    )
                 paths.append(hits[0])
             except Exception as e:
                 print("Unable to find {0} in {1} ({2})".format(f, indir, e))
@@ -411,7 +421,9 @@ class ReportSC2:
             for sample in artic_data.keys():
                 if sample in var_all.keys():
                     if len(var_all[sample]) > 1:
-                        artic_data[sample].update({"variants": ";".join(var_all[sample])})
+                        artic_data[sample].update(
+                            {"variants": ";".join(var_all[sample])}
+                        )
                     else:
                         artic_data[sample].update({"variants": var_all[sample]})
                 else:
@@ -428,9 +440,12 @@ class ReportSC2:
             elif artic_data[sample]["lineage"] in voc_strains["lineage"]:
                 index = voc_strains["lineage"].index(artic_data[sample]["lineage"])
                 # Check for spike
-                if pandas.isna(voc_strains["spike"][index]) or voc_strains["spike"][index] in artic_data[sample]["variants"]:
+                if (
+                    pandas.isna(voc_strains["spike"][index])
+                    or voc_strains["spike"][index] in artic_data[sample]["variants"]
+                ):
                     # Add variant class
-                    artic_data[sample].update( {"VOC":voc_strains["class"][index]} )
+                    artic_data[sample].update({"VOC": voc_strains["class"][index]})
 
         self.articdata.update(artic_data)
 
@@ -622,7 +637,9 @@ class ReportSC2:
             {
                 "format": "csv",
                 "id": self.case,
-                "path": os.path.join(self.indir, "{}_komplettering.csv".format(self.ticket)),
+                "path": os.path.join(
+                    self.indir, "{}_komplettering.csv".format(self.ticket)
+                ),
                 "path_index": "~",
                 "step": "report",
                 "tag": "SARS-CoV-2-info",

--- a/mutant/modules/sarscov2_start.py
+++ b/mutant/modules/sarscov2_start.py
@@ -12,7 +12,8 @@ from mutant.modules.generic_parser import get_json
 
 class RunSC2:
     def __init__(
-        self, input_folder, caseID, prefix, profiles, timestamp, WD, config_artic=""):
+        self, input_folder, caseID, prefix, profiles, timestamp, WD, config_artic=""
+    ):
 
         self.fastq = input_folder
         self.timestamp = timestamp
@@ -30,10 +31,12 @@ class RunSC2:
             resdir = outdir
         elif config != "":
             general_config = get_json(config)
-            resdir = os.path.abspath(os.path.join(
-                general_config["SARS-CoV-2"]["folders"]["results"],
-                "{}_{}".format(self.case, self.timestamp),
-            ))
+            resdir = os.path.abspath(
+                os.path.join(
+                    general_config["SARS-CoV-2"]["folders"]["results"],
+                    "{}_{}".format(self.case, self.timestamp),
+                )
+            )
         else:
             resdir = os.path.abspath("results")
         return resdir

--- a/mutant/standalone/classifications.csv
+++ b/mutant/standalone/classifications.csv
@@ -2,7 +2,7 @@ lineage,spike,class
 B.1.1.7,,VOC
 B.1.1.7,E484,VOC
 B.1.351,,VOC
-P.1,VOC
+P.1,,VOC
 B.1.525,,VOI
 B.1.427,,VOI
 B.1.429,,VOI

--- a/mutant/standalone/concatenate.py
+++ b/mutant/standalone/concatenate.py
@@ -16,40 +16,52 @@ from pathlib import Path
 PREFIX_TO_CONCATENATE = ["MWG", "MWL", "MWM", "MWR", "MWX", "CONCATENATE"]
 parser = ArgumentParser()
 
-parser.add_argument("-i",
-                    "--input_folder",
-                    dest="input_folder",
-                    help="Folder with fastq to concatenate",
-                    metavar="<PATH>",
-                    required=True,
-                    type=str)
-parser.add_argument("-a",
-                    "--app_tag",
-                    dest="app_tag",
-                    help="Application tag",
-                    metavar="<STRING>",
-                    required=False,
-                    type=str,
-                    default="CONCATENATE")
-parser.add_argument("-d",
-                    "--date",
-                    dest="date",
-                    help="Date to add to the concatenated file name, e.g. order date",
-                    metavar="<DATE>",
-                    required=False,
-                    type=str,
-                    default="")
+parser.add_argument(
+    "-i",
+    "--input_folder",
+    dest="input_folder",
+    help="Folder with fastq to concatenate",
+    metavar="<PATH>",
+    required=True,
+    type=str,
+)
+parser.add_argument(
+    "-a",
+    "--app_tag",
+    dest="app_tag",
+    help="Application tag",
+    metavar="<STRING>",
+    required=False,
+    type=str,
+    default="CONCATENATE",
+)
+parser.add_argument(
+    "-d",
+    "--date",
+    dest="date",
+    help="Date to add to the concatenated file name, e.g. order date",
+    metavar="<DATE>",
+    required=False,
+    type=str,
+    default="",
+)
 
 args = parser.parse_args()
 should_concatenate = False
 
 for prefix in PREFIX_TO_CONCATENATE:
     if args.app_tag.startswith(prefix):
-        print("Apptag %s identified, data generated with this application tag should be concatenated" % (args.app_tag))
+        print(
+            "Apptag %s identified, data generated with this application tag should be concatenated"
+            % (args.app_tag)
+        )
         should_concatenate = True
 
 if should_concatenate == False:
-    print("Data with application tag %s should not be concatenated, skipping concatenation" % (args.app_tag))
+    print(
+        "Data with application tag %s should not be concatenated, skipping concatenation"
+        % (args.app_tag)
+    )
     sys.exit(-1)
 
 for dir_name in os.listdir(args.input_folder):
@@ -77,7 +89,16 @@ for dir_name in os.listdir(args.input_folder):
         for i in range(len(same_direction)):
             cmd = cmd + " " + same_direction[i]
         if args.date:
-            output = dir_path + "/" + str(args.date) + "_" + dir_name + "_" + str(read_direction) + ".fastq.gz"
+            output = (
+                dir_path
+                + "/"
+                + str(args.date)
+                + "_"
+                + dir_name
+                + "_"
+                + str(read_direction)
+                + ".fastq.gz"
+            )
         else:
             output = dir_path + "/" + dir_name + "_" + str(read_direction) + ".fastq.gz"
         cmd = cmd + " > " + output

--- a/mutant/standalone/deploy_hasta_update.sh
+++ b/mutant/standalone/deploy_hasta_update.sh
@@ -32,3 +32,4 @@ git submodule foreach 'git fetch origin; git checkout $(git rev-parse --abbrev-r
 
 # Pull latest image
 singularity pull --force /home/proj/${INSTANCE}/mutant/MUTANT/mutant/externals/gms-artic/artic-ncov2019-illumina.sif docker://clinicalgenomics/artic-ncov2019-illumina:latest
+chmod u=rwx,g=rx,o=rx mutant/externals/gms-artic/artic-ncov2019-illumina.sif


### PR DESCRIPTION
### The purpose of the code changes are as follows:
-  Add code by Isak to update the sars-cov-2 report.
   - column "variants" changed to "mutations"
   - column "VOC" will show values for all classes (including VOC, VOI, VUM etc) as defined in `mutant/standalone/classifications.csv`
   - new column for region codes
   
- Also added chmod of singularity image in deploy

### Preparations:

**How to prepare mutant for test**:
* `bash mutant/standalone/deploy_hasta_update.sh stage update_report`

**How to prepare cg for test**:
- `us`
- Paxa and update cg or other tools needed for the test:
  - `paxa -u <user> -s hasta -r cg-stage`
  - `paxa -u <user> -s hasta -r servers-stage`
  - `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh master`
  - `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-servers-stage.sh master`
  

### How to test:
Run in a tmux screen or similar if testing on a large dataset.

**Test with cg**:
- `us`
- `cg workflow mutant start eagereel`

### Expected outcome:
- [x] Produced files contain expected values
- [x] Singularity image has correct permissions

### Review:
- [x] Code reviewed @Mropat 

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
