### PR TITLE
Update artic 5a1bc1f

### DIFF
--- a/mutant/config/hasta/artic-prod.json
+++ b/mutant/config/hasta/artic-prod.json
@@ -27,7 +27,7 @@ params {
     help = false
     tracedir = "${params.outdir}/pipeline_info"
     // cache option makes it a bit easier to set conda or singularity cacheDir
-    cache = "/home/proj/development/microbial/sars-cov-2/nf-cache/"
+    cache = "/home/proj/production/mutant/nf-cache/"
     // Scheme name
     scheme = 'nCoV-2019'
     // Scheme version
@@ -93,7 +93,7 @@ if ( params.illumina ) {
         // Options for picard CollectWgsMetrics
         wgsMetricsOptions = "--COVERAGE_CAP 1000000 --LOCUS_ACCUMULATION_CAP 1000000"
         // Customization of multiQC report
-        multiqcOptions = '--cl_config "picard_config: { general_stats_target_coverage: [10,30,50,100] }"'
+        multiqcOptions = '--cl_config "picard_config: { general_stats_target_coverage: [10,30,50,100] }" --module cutadapt --module fastqc --module ivar --module picard'
     }
 }
 

--- a/mutant/config/hasta/artic-stage.json
+++ b/mutant/config/hasta/artic-stage.json
@@ -27,7 +27,7 @@ params {
     help = false
     tracedir = "${params.outdir}/pipeline_info"
     // cache option makes it a bit easier to set conda or singularity cacheDir
-    cache = "/home/proj/development/microbial/sars-cov-2/nf-cache/"
+    cache = "/home/proj/stage/mutant/nf-cache/"
     // Scheme name
     scheme = 'nCoV-2019'
     // Scheme version
@@ -93,7 +93,7 @@ if ( params.illumina ) {
         // Options for picard CollectWgsMetrics
         wgsMetricsOptions = "--COVERAGE_CAP 1000000 --LOCUS_ACCUMULATION_CAP 1000000"
         // Customization of multiQC report
-        multiqcOptions = '--cl_config "picard_config: { general_stats_target_coverage: [10,30,50,100] }"'
+        multiqcOptions = '--cl_config "picard_config: { general_stats_target_coverage: [10,30,50,100] }" --module cutadapt --module fastqc --module ivar --module picard'
     }
 }
 

--- a/mutant/config/hasta/artic.json
+++ b/mutant/config/hasta/artic.json
@@ -27,7 +27,7 @@ params {
     help = false
     tracedir = "${params.outdir}/pipeline_info"
     // cache option makes it a bit easier to set conda or singularity cacheDir
-    cache = "/home/proj/development/microbial/sars-cov-2/nf-cache/"
+    cache = "/home/proj/production/mutant/nf-cache/"
     // Scheme name
     scheme = 'nCoV-2019'
     // Scheme version
@@ -93,7 +93,7 @@ if ( params.illumina ) {
         // Options for picard CollectWgsMetrics
         wgsMetricsOptions = "--COVERAGE_CAP 1000000 --LOCUS_ACCUMULATION_CAP 1000000"
         // Customization of multiQC report
-        multiqcOptions = '--cl_config "picard_config: { general_stats_target_coverage: [10,30,50,100] }"'
+        multiqcOptions = '--cl_config "picard_config: { general_stats_target_coverage: [10,30,50,100] }" --module cutadapt --module fastqc --module ivar --module picard'
     }
 }
 

--- a/mutant/config/local/artic.json
+++ b/mutant/config/local/artic.json
@@ -92,7 +92,7 @@ if ( params.illumina ) {
         // Options for picard CollectWgsMetrics
         wgsMetricsOptions = "--COVERAGE_CAP 10000 --LOCUS_ACCUMULATION_CAP 100000"
         // Customization of multiQC report
-        multiqcOptions = '--cl_config "picard_config: { general_stats_target_coverage: [10,30,50,100] }"'
+        multiqcOptions = '--cl_config "picard_config: { general_stats_target_coverage: [10,30,50,100] }" --module cutadapt --module fastqc --module ivar --module picard'
     }
 }
 

--- a/mutant/standalone/deploy_hasta_update.sh
+++ b/mutant/standalone/deploy_hasta_update.sh
@@ -28,7 +28,7 @@ git pull origin master
 cd ${OLDDIR}
 git submodule init
 git submodule update
-git submodule foreach 'git fetch origin; git checkout $(git rev-parse --abbrev-ref HEAD); git reset --hard origin/$(git rev-parse --abbrev-ref HEAD); git submodule update --recursive; git clean -dfx'
+#git submodule foreach 'git fetch origin; git checkout $(git rev-parse --abbrev-ref HEAD); git reset --hard origin/$(git rev-parse --abbrev-ref HEAD); git submodule update --recursive; git clean -dfx'
 
 # Pull latest image
 singularity pull --force /home/proj/${INSTANCE}/mutant/MUTANT/mutant/externals/gms-artic/artic-ncov2019-illumina.sif docker://clinicalgenomics/artic-ncov2019-illumina:latest


### PR DESCRIPTION
### The purpose of the code changes are as follows:
-  Updated gms-artic ref to (third times the charm) ~~5a1bc1f, 8d73d2f~~ 8b7f846
- Updated cache paths in configs
- Updated mutliqc params in overriding MUTANT config
- Removed submodule updates to master for now

### Preparations:

**How to prepare mutant for test**:
* `bash mutant/standalone/deploy_hasta_update.sh stage update_artic_5a1bc1f`

**How to prepare cg for test**:
- `us`
- Paxa and update cg or other tools needed for the test:
  - `paxa -u <user> -s hasta -r cg-stage`
  - `bash update-cg-stage.sh master`
  

### How to test:
Run in a tmux screen or similar if testing on a large dataset.

**Test with cg**:
- `us`
- `cg workflow mutant start maturejay`

### Expected outcome:
- [x] Produced files contain expected values

### Review:
- [x] Code reviewed by @Mropat 

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
