### PR TITLE
Add check for sequencing QC fail

### DIFF
--- a/mutant/modules/artic_illumina/report.py
+++ b/mutant/modules/artic_illumina/report.py
@@ -118,14 +118,29 @@ class ReportSC2:
         )
         # Add info about failed/passed QC
         for record in self.caseinfo:
-            sample_yaml = {
-                "header": "~",
-                "id": record["CG_ID_sample"],
-                "input": os.path.basename(self.filepaths[self.case]["results-file"]),
-                "name": "passed-qc",
-                "step": "QC-threshold",
-                "value": self.articdata[record["Customer_ID_sample"]]["qc"],
-            }
+            if record["sequencing_qc_pass"]:
+                sample_yaml = {
+                    "header": "~",
+                    "id": record["CG_ID_sample"],
+                    "input": os.path.basename(
+                        self.filepaths[self.case]["results-file"]
+                    ),
+                    "name": "passed-qc",
+                    "step": "QC-threshold",
+                    "value": self.articdata[record["Customer_ID_sample"]]["qc"],
+                }
+            # Sample failed QC and has not been analyzed
+            else:
+                sample_yaml = {
+                    "header": "~",
+                    "id": record["CG_ID_sample"],
+                    "input": os.path.basename(
+                        self.filepaths[self.case]["results-file"]
+                    ),
+                    "name": "passed-qc",
+                    "step": "QC-threshold",
+                    "value": "FALSE",
+                }
             out_yaml["metrics"].append(sample_yaml)
         # Create output file
         with open(self.filepaths[self.case]["vogue-metrics"], "w") as out:


### PR DESCRIPTION
### The purpose of the code changes are as follows:
Fixed bug:
-  missing vogue file creation catch for samples that have not been analysed. These samples have failed in sequencing qc and have therefore not been analysed.

### Preparations:

**How to prepare mutant for test**:
* `bash deploy_hasta_update.sh stage fix_check_seqQC`

### How to test:
Run in a tmux screen or similar if testing on a large dataset.

**Test with cg**:
- `us`
- `conda activate S_mutant`
- `mutant toolbox sarscov2 postproc` for case realpossum

### Expected outcome:
- [x] Produced files contain expected values

### Review:
- [ ] Code reviewed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
