### PR TITLE
Updated image used during deploy

### DIFF
--- a/mutant/standalone/deploy_hasta_update.sh
+++ b/mutant/standalone/deploy_hasta_update.sh
@@ -31,5 +31,5 @@ git submodule update
 #git submodule foreach 'git fetch origin; git checkout $(git rev-parse --abbrev-ref HEAD); git reset --hard origin/$(git rev-parse --abbrev-ref HEAD); git submodule update --recursive; git clean -dfx'
 
 # Pull latest image
-singularity pull --force /home/proj/${INSTANCE}/mutant/MUTANT/mutant/externals/gms-artic/artic-ncov2019-illumina.sif docker://clinicalgenomics/artic-ncov2019-illumina:latest
+singularity pull --force /home/proj/${INSTANCE}/mutant/MUTANT/mutant/externals/gms-artic/artic-ncov2019-illumina.sif docker://genomicmedicinesweden/gms-artic-illumina:2021-11-30-p-3.1.16-L-2021-11-18-c-0.0.24-d-1.2.103-s-0.3.14
 chmod u=rwx,g=rx,o=rx mutant/externals/gms-artic/artic-ncov2019-illumina.sif


### PR DESCRIPTION
### The purpose of the code changes are as follows:
-  Change image used from clinicalgenomics dockerhub to genomicmedicinesweden.
- This image is updated automatically.
- For now specify tag name instead of latest tag.

### Preparations:

**How to prepare mutant for test**:
* `bash mutant/standalone/deploy_hasta_update.sh stage update_docker_image_location`

### How to test:
Run in a tmux screen or similar if testing on a large dataset.

**Test with MUTANT**:
- `conda activate S_mutant`
- `mutant analyse sarscov2 --config_case /home/proj/stage/mutant/cases/maturejay/case_config.json --outdir /home/proj/stage/mutant/cases/maturejay/results/ --config_artic /home/proj/stage/mutant/MUTANT/mutant/config/hasta/artic-stage.json /home/proj/stage/mutant/cases/maturejay/fastq/`

### Expected outcome:
- [x] Produced files contain expected values

### Review:
- [x] Code reviewed by @sofstam 

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
