### PR TITLE
changed qc_flag for 10x coverage

### DIFF
--- a/mutant/modules/artic_illumina/parser.py
+++ b/mutant/modules/artic_illumina/parser.py
@@ -166,7 +166,7 @@ def get_artic_results(indir) -> dict:
         next(content)
         for line in content:
             sample = line[0].split("_")[-1]
-            if float(line[2]) > 95:
+            if float(line[2]) >= 90:
                 qc_flag = "TRUE"
             else:
                 qc_flag = "FALSE"


### PR DESCRIPTION
### The purpose of the code changes are as follows:
Change so QC is passed for samples with 90% or more of the genome got 10x or more coverage

### Preparations:

**How to prepare mutant for test**:
* `bash /home/proj/stage/mutant/MUTANT/mutant/standalone/deploy_hasta_update.sh stage 10xcoverage`

**How to prepare cg for test**:
- `us`
- Paxa and update cg or other tools needed for the test:
  - `paxa -u <user> -s hasta -r cg-stage`
  - `paxa -u <user> -s hasta -r servers-stage`
  - `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh master`
  - `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-servers-stage.sh master`
  

### How to test:
Run in a tmux screen or similar if testing on a large dataset.

**Test with cg**:
- `us`
- `cg workflow mutant start maturejay`

### Expected outcome:
- [ ] Produced files contain expected values

### Review:
- [ ] Code reviewed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
