### PR TITLE
Set column "QC_pass" in sars-cov-2_<ticket_id>_results.csv to "FALSE" if lineage is "None"

### DIFF
--- a/mutant/modules/artic_illumina/report.py
+++ b/mutant/modules/artic_illumina/report.py
@@ -296,7 +296,10 @@ class ReportSC2:
                 if "pct_10X_bases" in data:
                     tenx_bases = data["pct_10X_bases"]
                 if "qc" in data:
-                    qc_status = data["qc"]
+                    if data["lineage"] == "None":
+                        qc_status = "FALSE"
+                    else:
+                        qc_status = data["qc"]
                 if "lineage" in data:
                     lineage = data["lineage"]
                 if "pangoLEARN_version" in data and data["pangoLEARN_version"] != "":


### PR DESCRIPTION
### The purpose of the code changes are as follows:
This PR will wet column "QC_pass" in sars-cov-2_<ticket_id>_results.csv to "FALSE" if lineage is "None". This will ultimately lead to lower risk that KS accidentally register the result in national databases.

### Preparations:

**How to prepare mutant for test**:
* `bash /home/proj/stage/mutant/MUTANT/mutant/standalone/deploy_hasta_update.sh stage qc-fail-if-none`

**How to prepare cg for test**:
- `us`
- Paxa and update cg or other tools needed for the test:
  - `paxa -u <user> -s hasta -r cg-stage`
  - `paxa -u <user> -s hasta -r servers-stage`
  - `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-cg-stage.sh master`
  - `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-servers-stage.sh master`
  

### How to test:
Run in a tmux screen or similar if testing on a large dataset.

**Test with cg**:
- `us`
- `cg workflow mutant start maturejay`

### Expected outcome:
- [x] Produced files contain expected values

### Review:
- [ ] Code reviewed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
