### PR TITLE
Adapt to new pangolin output

### DIFF
--- a/mutant/modules/artic_illumina/parser.py
+++ b/mutant/modules/artic_illumina/parser.py
@@ -200,8 +200,8 @@ def get_artic_results(indir) -> dict:
                     {
                         "lineage": line[1],
                         "pangolin_probability": line[3],
-                        "pangoLEARN_version": line[-4],
-                        "pangolin_qc": line[-2],
+                        "pangoLEARN_version": line[-7],
+                        "pangolin_qc": line[-3],
                     }
                 )
 

--- a/mutant/modules/artic_illumina/parser.py
+++ b/mutant/modules/artic_illumina/parser.py
@@ -200,7 +200,7 @@ def get_artic_results(indir) -> dict:
                     {
                         "lineage": line[1],
                         "pangolin_probability": line[3],
-                        "pangolin_version": line[-7],
+                        "pangolin_data_version": line[8],
                         "pangolin_qc": line[-3],
                     }
                 )

--- a/mutant/modules/artic_illumina/parser.py
+++ b/mutant/modules/artic_illumina/parser.py
@@ -200,7 +200,7 @@ def get_artic_results(indir) -> dict:
                     {
                         "lineage": line[1],
                         "pangolin_probability": line[3],
-                        "pangoLEARN_version": line[-7],
+                        "pangolin_version": line[-7],
                         "pangolin_qc": line[-3],
                     }
                 )

--- a/mutant/modules/artic_illumina/report.py
+++ b/mutant/modules/artic_illumina/report.py
@@ -175,7 +175,7 @@ class ReportSC2:
         """Concatenate pangolin results and format for fohm"""
 
         indir = "{0}/ncovIllumina_sequenceAnalysis_pangolinTyping".format(self.indir)
-        concatfile = "{0}/{1}_{2}_pangolin_classification_format3.txt".format(
+        concatfile = "{0}/{1}_{2}_pangolin_classification_format4.txt".format(
             self.indir, self.ticket, str(date.today())
         )
         pangolins = glob.glob("{0}/*.pangolin.csv".format(indir))
@@ -416,7 +416,7 @@ class ReportSC2:
             {
                 "format": "csv",
                 "id": self.case,
-                "path": "{}/{}_{}_pangolin_classification_format3.txt".format(
+                "path": "{}/{}_{}_pangolin_classification_format4.txt".format(
                     self.indir, self.ticket, str(date.today())
                 ),
                 "path_index": "~",

--- a/mutant/modules/artic_illumina/report.py
+++ b/mutant/modules/artic_illumina/report.py
@@ -274,7 +274,7 @@ class ReportSC2:
                     "%10X_coverage",
                     "QC_pass",
                     "Lineage",
-                    "PangoLEARN_version",
+                    "Pangolin_version",
                     "VOC",
                     "Mutations",
                 ]
@@ -302,8 +302,8 @@ class ReportSC2:
                         qc_status = data["qc"]
                 if "lineage" in data:
                     lineage = data["lineage"]
-                if "pangoLEARN_version" in data and data["pangoLEARN_version"] != "":
-                    verzion = data["pangoLEARN_version"]
+                if "pangolin_version" in data and data["pangolin_version"] != "":
+                    verzion = data["pangolin_version"]
                 if "VOC" in data:
                     vocs = data["VOC"]
                 if "VOC_aa" in data:

--- a/mutant/modules/artic_illumina/report.py
+++ b/mutant/modules/artic_illumina/report.py
@@ -274,7 +274,7 @@ class ReportSC2:
                     "%10X_coverage",
                     "QC_pass",
                     "Lineage",
-                    "Pangolin_version",
+                    "Pangolin_data_version",
                     "VOC",
                     "Mutations",
                 ]
@@ -302,8 +302,8 @@ class ReportSC2:
                         qc_status = data["qc"]
                 if "lineage" in data:
                     lineage = data["lineage"]
-                if "pangolin_version" in data and data["pangolin_version"] != "":
-                    verzion = data["pangolin_version"]
+                if "pangolin_data_version" in data and data["pangolin_data_version"] != "":
+                    verzion = data["pangolin_data_version"]
                 if "VOC" in data:
                     vocs = data["VOC"]
                 if "VOC_aa" in data:


### PR DESCRIPTION
Before pangolin gave an .csv as output with the following headers:
`taxon,lineage,conflict,ambiguity_score,scorpio_call,scorpio_support,scorpio_conflict,version,pangolin_version,pangoLEARN_version,pango_version,status,note`

Now pangolin will give an .csv output with the following headers:
`taxon,lineage,conflict,ambiguity_score,scorpio_call,scorpio_support,scorpio_conflict,scorpio_notes,version,pangolin_version,scorpio_version,constellation_version,is_designated,qc_status,qc_notes,note`

In a file given as output by MUTANT (`...pangolin_classification_format3.txt`) we have the following headers:
`taxon,lineage,conflict,ambiguity_score,scorpio_call,scorpio_support,scorpio_conflict,version,pangolin_version,pangoLEARN_version,pango_version,status,note`

The `...pangolin_classification_format3.txt` is now going to be upgraded to `...pangolin_classification_format4.txt` with the following headers:
`taxon,lineage,conflict,ambiguity_score,scorpio_call,scorpio_support,scorpio_conflict,scorpio_notes,version,pangolin_version,scorpio_version,constellation_version,is_designated,qc_status,qc_notes,note`

From the `...pangolin_classification_formatX.txt` file we collect information regarding `lineage`, `ambiguity_score`,  `pangoLEARN_version` and `qc_status`. While `lineage` and `ambiguity_score` stay in the same column index we need to take into consideration that the `pangoLEARN_version` column gets deprecated and `status` column change place.

I suggest we display `pangolin_version` from now on in the customer reports.

### Preparations:

**How to prepare mutant for test**:
* `cd MUTANT`
* `bash mutant/standalone/deploy_hasta_update.sh stage <MUTANT_branch>`

**How to prepare cg for test**:
- `us`
- Paxa and update cg:
  - `paxa -u <user> -s hasta -r cg-stage`
  - `bash update-cg-stage.sh master`
- If needed, paxa and update servers:
  - `paxa -u <user> -s hasta -r servers-stage`
  - `bash update-servers-stage.sh <master/branch>`
  
### How to test:
Run in a tmux screen or similar if testing on a large dataset.

**Test with cg**:
- `us`
- `cg workflow mutant start maturejay`

### Expected outcome:
- [ ] Produced files contain expected values

### Review:
- [ ] Code reviewed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
