### PR TITLE
Remove editing of selection criteria

### DIFF
--- a/mutant/modules/generic_parser.py
+++ b/mutant/modules/generic_parser.py
@@ -37,9 +37,6 @@ def get_sarscov2_config(config) -> dict:
     for i in range(len(caseinfo)):
         caseinfo[i]["region_code"] = caseinfo[i]["region_code"].replace(" ", "_")
         caseinfo[i]["lab_code"] = caseinfo[i]["lab_code"].replace(" ", "_")
-        caseinfo[i]["selection_criteria"] = (
-            caseinfo[i]["selection_criteria"].split(".")[1].strip()
-        )
     return caseinfo
 
 


### PR DESCRIPTION
### The purpose of the code changes are as follows:
Before orderform contained selection criteria:
"1. Allmän övervakning"
"2. Utbrottsutredning"
"3. Vaccinationsgenombrott"
"4. Utland"
"5. SGTF"
"6. Reinfektion"
"7. Information saknas"

Now the digit will be removed, therefore editing the selection criteria via mutant is not needed anymore.

### Preparations:

**How to prepare mutant for test**:
* `cd MUTANT`
* `bash mutant/standalone/deploy_hasta_update.sh stage <MUTANT_branch>`

**How to prepare cg for test**:
- `us`
- Paxa and update cg:
  - `paxa -u <user> -s hasta -r cg-stage`
  - `bash update-cg-stage.sh master`
- If needed, paxa and update servers:
  - `paxa -u <user> -s hasta -r servers-stage`
  - `bash update-servers-stage.sh <master/branch>`
  
### How to test:
Run in a tmux screen or similar if testing on a large dataset.

**Test with cg**:
- `us`
- `cg workflow mutant start maturejay`

### Expected outcome:
- [ ] Produced files contain expected values

### Review:
- [ ] Code reviewed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
