### PR TITLE
conditional number removal from selection criteria

### DIFF
--- a/mutant/modules/generic_parser.py
+++ b/mutant/modules/generic_parser.py
@@ -39,7 +39,7 @@ def get_sarscov2_config(config) -> dict:
         caseinfo[i]["lab_code"] = caseinfo[i]["lab_code"].replace(" ", "_")
         selection_criteria = caseinfo[i]["selection_criteria"]
         first_character = selection_criteria[:1]
-        if isinstance(first_character, int):
+        if first_character.isnumeric():
             caseinfo[i]["selection_criteria"] = (
                 caseinfo[i]["selection_criteria"].split(".")[1].strip()
             )

--- a/mutant/modules/generic_parser.py
+++ b/mutant/modules/generic_parser.py
@@ -37,7 +37,8 @@ def get_sarscov2_config(config) -> dict:
     for i in range(len(caseinfo)):
         caseinfo[i]["region_code"] = caseinfo[i]["region_code"].replace(" ", "_")
         caseinfo[i]["lab_code"] = caseinfo[i]["lab_code"].replace(" ", "_")
-        first_character = caseinfo[i]["selection_criteria"][:1]
+        selection_criteria = caseinfo[i]["selection_criteria"]
+        first_character = selection_criteria[:1]
         if isinstance(first_character, int):
             caseinfo[i]["selection_criteria"] = (
                 caseinfo[i]["selection_criteria"].split(".")[1].strip()

--- a/mutant/modules/generic_parser.py
+++ b/mutant/modules/generic_parser.py
@@ -37,6 +37,11 @@ def get_sarscov2_config(config) -> dict:
     for i in range(len(caseinfo)):
         caseinfo[i]["region_code"] = caseinfo[i]["region_code"].replace(" ", "_")
         caseinfo[i]["lab_code"] = caseinfo[i]["lab_code"].replace(" ", "_")
+        first_character = caseinfo[i]["selection_criteria"][:1]
+        if isinstance(first_character, int):
+            caseinfo[i]["selection_criteria"] = (
+                caseinfo[i]["selection_criteria"].split(".")[1].strip()
+            )
     return caseinfo
 
 


### PR DESCRIPTION
### The purpose of the code changes are as follows:
-  https://github.com/Clinical-Genomics/MUTANT/pull/140 gave support for the new orderform. However old orders might still be analyzed with the new version of mutant. This PR fix conditional removal of the integer that might be at the start of each selection critiera.

### Preparations:

**How to prepare mutant for test**:
* `cd MUTANT`
* `bash mutant/standalone/deploy_hasta_update.sh stage <MUTANT_branch>`

**How to prepare cg for test**:
- `us`
- Paxa and update cg:
  - `paxa -u <user> -s hasta -r cg-stage`
  - `bash update-cg-stage.sh master`
- If needed, paxa and update servers:
  - `paxa -u <user> -s hasta -r servers-stage`
  - `bash update-servers-stage.sh <master/branch>`
  
### How to test:
Run in a tmux screen or similar if testing on a large dataset.

**Test with cg**:
- `us`
- `cg workflow mutant start maturejay`

### Expected outcome:
- [ ] Produced files contain expected values

### Review:
- [ ] Code reviewed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
