### PR TITLE
Changing threads in fastqc via config

### DIFF
--- a/mutant/config/hasta/default_config.json
+++ b/mutant/config/hasta/default_config.json
@@ -19,7 +19,6 @@ process {
     }
     withName: fastqc {
         cpus = 2
-        ext.args = "--dir ~/tmp"
     }
 }
 

--- a/mutant/config/hasta/default_config.json
+++ b/mutant/config/hasta/default_config.json
@@ -17,6 +17,10 @@ process {
     withLabel: largemem {
         memory = '48 GB'
     }
+    withName: fastqc {
+        cpus = 2
+        ext.args = "--dir ~/tmp"
+    }
 }
 
 // Load base.config by default for all pipelines

--- a/mutant/config/hasta/default_config_stage.json
+++ b/mutant/config/hasta/default_config_stage.json
@@ -19,7 +19,6 @@ process {
     }
     withName: fastqc {
         cpus = 2
-        ext.args = "--dir ~/tmp"
     }
 }
 

--- a/mutant/config/hasta/default_config_stage.json
+++ b/mutant/config/hasta/default_config_stage.json
@@ -17,6 +17,10 @@ process {
     withLabel: largemem {
         memory = '48 GB'
     }
+    withName: fastqc {
+        cpus = 2
+        ext.args = "--dir ~/tmp"
+    }
 }
 
 // Load base.config by default for all pipelines


### PR DESCRIPTION
### The purpose of the code changes are as follows:
Changing the number of threads used when running fastqc can be necessary to not get java errors (related to memory)

### Preparations:

**How to prepare mutant for test**:
* `cd MUTANT`
* `bash mutant/standalone/deploy_hasta_update.sh stage fastqc-processes`

**How to prepare cg for test**:
- `us`
- Paxa and update cg:
  - `paxa -u <user> -s hasta -r cg-stage`
  - `bash update-cg-stage.sh master`
- If needed, paxa and update servers:
  - `paxa -u <user> -s hasta -r servers-stage`
  - `bash update-servers-stage.sh <master/branch>`
  
### How to test:
Run in a tmux screen or similar if testing on a large dataset.

**Test with cg**:
- `us`
- `cg workflow mutant start maturejay`

### Expected outcome:
- [ ] Produced files contain expected values

### Review:
- [ ] Code reviewed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
