### PR TITLE
Parse limsid instead of barcodes

### DIFF
--- a/mutant/cli.py
+++ b/mutant/cli.py
@@ -37,7 +37,6 @@ def analyse(ctx):
 @click.option(
     "--config_artic",
     help="Custom artic configuration file",
-    default="",
 )
 @click.option("--config_case", help="Provided config for the case")
 @click.option(

--- a/mutant/cli.py
+++ b/mutant/cli.py
@@ -37,9 +37,9 @@ def analyse(ctx):
 @click.option(
     "--config_artic",
     help="Custom artic configuration file",
-    default="{}/config/hasta/default_config.json".format(WD),
+    default="",
 )
-@click.option("--config_case", help="Provided config for the case", default="")
+@click.option("--config_case", help="Provided config for the case")
 @click.option(
     "--config_mutant",
     help="General configuration file for MUTANT",
@@ -56,22 +56,30 @@ def analyse(ctx):
 )
 @click.pass_context
 def sarscov2(
-    ctx, input_folder, config_artic, config_case, config_mutant, outdir, profiles, nanopore
+    ctx,
+    input_folder,
+    config_artic,
+    config_case,
+    config_mutant,
+    outdir,
+    profiles,
+    nanopore,
 ):
 
-    # Set base for output files (Move this section)
-    if config_case != "":
-        caseinfo = get_json(config_case)
-        caseID = caseinfo[0]["case_ID"]
-    else:
-        caseID = "artic"
+    if not config_case:
+        log.debug("No case config given, mutant needs a case config to run analysis")
+
+    caseinfo = get_json(config_case)
+    caseID = caseinfo[0]["case_ID"]
     prefix = "{}_{}".format(caseID, TIMESTAMP)
 
+    primer_json = caseinfo[0]["primer"].replace(" ", "_")
     if not config_artic:
-        caseinfo = get_json(config_case)
-        primer_json = caseinfo[0]["primer"].replace(" ", "_")
         primer_config = "{}/config/hasta/" + primer_json.lower() + ".json"
         config_artic = primer_config.format(WD)
+
+    if "nanopore" in primer_json.lower():
+        nanopore = True
 
     # Run
     run = RunSC2(

--- a/mutant/cli.py
+++ b/mutant/cli.py
@@ -67,6 +67,12 @@ def sarscov2(
         caseID = "artic"
     prefix = "{}_{}".format(caseID, TIMESTAMP)
 
+    if not config_artic:
+        caseinfo = get_json(config_case)
+        primer_json = caseinfo[0]["primer"].replace(" ", "_")
+        primer_config = "{}/config/hasta/" + primer_json.lower() + ".json"
+        config_artic = primer_config.format(WD)
+
     # Run
     run = RunSC2(
         input_folder=input_folder,

--- a/mutant/constants/artic.py
+++ b/mutant/constants/artic.py
@@ -6,7 +6,7 @@ ILLUMINA_FILES_CASE = {
     "multiqc-html": "{resdir}/QCStats/ncovIllumina_sequenceAnalysis_multiqc/*_multiqc.html",
     "vogue-metrics": "{resdir}/{case}_metrics_deliverables.yaml",
     "results-file": "{resdir}/sars-cov-2_{ticket}_results.csv",
-    "versions-file": "{resdir}/ncovIllumina_sequenceAnalysis_versions/*_versions.csv"
+    "versions-file": "{resdir}/ncovIllumina_sequenceAnalysis_versions/*_versions.csv",
 }
 
 # GMS-Artic and MUTANT output files for Nanopore

--- a/mutant/modules/artic_illumina/report.py
+++ b/mutant/modules/artic_illumina/report.py
@@ -302,7 +302,10 @@ class ReportSC2:
                         qc_status = data["qc"]
                 if "lineage" in data:
                     lineage = data["lineage"]
-                if "pangolin_data_version" in data and data["pangolin_data_version"] != "":
+                if (
+                    "pangolin_data_version" in data
+                    and data["pangolin_data_version"] != ""
+                ):
                     verzion = data["pangolin_data_version"]
                 if "VOC" in data:
                     vocs = data["VOC"]

--- a/mutant/modules/artic_nanopore/parser.py
+++ b/mutant/modules/artic_nanopore/parser.py
@@ -7,6 +7,7 @@ from mutant.modules.generic_parser import get_sarscov2_config, parse_classificat
 
 QC_PASS_THRESHOLD_COVERAGE_10X_OR_HIGHER = 90
 
+
 class ParserNanopore:
     def __init__(self, caseinfo: str):
         self.caseinfo = caseinfo
@@ -40,7 +41,9 @@ class ParserNanopore:
         for sample in parsed_config:
             cust_sample_id = sample["Customer_ID_sample"]
             data_to_report[cust_sample_id] = {}
-            data_to_report[cust_sample_id]["selection_criteria"] = sample["selection_criteria"]
+            data_to_report[cust_sample_id]["selection_criteria"] = sample[
+                "selection_criteria"
+            ]
             data_to_report[cust_sample_id]["region_code"] = sample["region_code"]
         return data_to_report
 
@@ -52,18 +55,26 @@ class ParserNanopore:
             for line in fasta:
                 stripped_line = line.strip()
                 total_bases += len(stripped_line)
-                total_N += stripped_line.count('N')
-            percentage_N_two_decimals = round((total_N/total_bases)*100, 2)
+                total_N += stripped_line.count("N")
+            percentage_N_two_decimals = round((total_N / total_bases) * 100, 2)
             return percentage_N_two_decimals
 
-    def parse_assembly(self, results: dict, resdir: str, limsid_to_sample: dict) -> dict:
+    def parse_assembly(
+        self, results: dict, resdir: str, limsid_to_sample: dict
+    ) -> dict:
         """Collects data by parsing the assembly"""
-        base_path = "/".join([resdir, "articNcovNanopore_sequenceAnalysisMedaka_articMinIONMedaka"])
+        base_path = "/".join(
+            [resdir, "articNcovNanopore_sequenceAnalysisMedaka_articMinIONMedaka"]
+        )
         for filename in os.listdir(base_path):
             if filename.endswith(".consensus.fasta"):
                 abs_path = os.path.join(base_path, filename)
-                first_line: str = self.get_line(filename=abs_path, line_index_of_interest=0)
-                cust_sample_id: str = self.get_cust_sample_id(line_to_parse=first_line, limsid_to_sample=limsid_to_sample)
+                first_line: str = self.get_line(
+                    filename=abs_path, line_index_of_interest=0
+                )
+                cust_sample_id: str = self.get_cust_sample_id(
+                    line_to_parse=first_line, limsid_to_sample=limsid_to_sample
+                )
                 fraction_N: float = self.get_fraction_n(input_file=abs_path)
                 results[cust_sample_id]["fraction_n_bases"] = fraction_N
         return results
@@ -92,21 +103,38 @@ class ParserNanopore:
                 coverage_stats.append(int(columns[3]))
         return coverage_stats
 
-    def calculate_coverage(self, results: dict, resdir: str, limsid_to_sample: dict) -> dict:
+    def calculate_coverage(
+        self, results: dict, resdir: str, limsid_to_sample: dict
+    ) -> dict:
         """Collects data for the fraction of each assembly that got 10x coverage or more"""
-        base_path = "/".join([resdir, "articNcovNanopore_sequenceAnalysisMedaka_articMinIONMedaka/"])
+        base_path = "/".join(
+            [resdir, "articNcovNanopore_sequenceAnalysisMedaka_articMinIONMedaka/"]
+        )
         for limsid in limsid_to_sample:
-            coverage_files_paths: list = self.get_depth_files_paths(limsid=limsid, base_path=base_path)
-            coverage_stats: list = self.initiate_coverage_stats_list(file_path=coverage_files_paths[0])
+            coverage_files_paths: list = self.get_depth_files_paths(
+                limsid=limsid, base_path=base_path
+            )
+            coverage_stats: list = self.initiate_coverage_stats_list(
+                file_path=coverage_files_paths[0]
+            )
             with open(coverage_files_paths[1], "r") as file2:
                 for line in file2:
                     stripped_line = line.strip()
                     columns: list = stripped_line.split("\t")
                     coverage_stats[int(columns[2])] += int(columns[3])
-            bases_w_10x_cov_or_more: int = self.count_bases_w_10x_cov_or_more(coverage_stats=coverage_stats)
-            percentage_equal_or_greater_than_10 = round((bases_w_10x_cov_or_more / len(coverage_stats)) * 100, 2)
-            results[limsid_to_sample[limsid]]["pct_10x_coverage"] = percentage_equal_or_greater_than_10
-            if percentage_equal_or_greater_than_10 >= QC_PASS_THRESHOLD_COVERAGE_10X_OR_HIGHER:
+            bases_w_10x_cov_or_more: int = self.count_bases_w_10x_cov_or_more(
+                coverage_stats=coverage_stats
+            )
+            percentage_equal_or_greater_than_10 = round(
+                (bases_w_10x_cov_or_more / len(coverage_stats)) * 100, 2
+            )
+            results[limsid_to_sample[limsid]][
+                "pct_10x_coverage"
+            ] = percentage_equal_or_greater_than_10
+            if (
+                percentage_equal_or_greater_than_10
+                >= QC_PASS_THRESHOLD_COVERAGE_10X_OR_HIGHER
+            ):
                 results[limsid_to_sample[limsid]]["qc_pass"] = "TRUE"
             else:
                 results[limsid_to_sample[limsid]]["qc_pass"] = "FALSE"
@@ -130,16 +158,26 @@ class ParserNanopore:
         voc_strains: dict = parse_classifications(csv_path=classifications_path)
         return voc_strains
 
-    def parse_pangolin(self, results: dict, limsid_to_sample: dict, resdir: str) -> dict:
+    def parse_pangolin(
+        self, results: dict, limsid_to_sample: dict, resdir: str
+    ) -> dict:
         """Collect data for pangolin types"""
-        base_path = "/".join([resdir, "articNcovNanopore_sequenceAnalysisMedaka_pangolinTyping"])
+        base_path = "/".join(
+            [resdir, "articNcovNanopore_sequenceAnalysisMedaka_pangolinTyping"]
+        )
         for filename in os.listdir(base_path):
             abs_path = os.path.join(base_path, filename)
-            second_line: str = self.get_line(filename=abs_path, line_index_of_interest=1)
-            cust_sample_id: str = self.get_cust_sample_id(line_to_parse=second_line, limsid_to_sample=limsid_to_sample)
+            second_line: str = self.get_line(
+                filename=abs_path, line_index_of_interest=1
+            )
+            cust_sample_id: str = self.get_cust_sample_id(
+                line_to_parse=second_line, limsid_to_sample=limsid_to_sample
+            )
             pangolin_type: str = self.get_pangolin_type(raw_pangolin_result=second_line)
             results[cust_sample_id]["pangolin_type"] = pangolin_type
-            pangoLEARN_version: str = self.get_pangoLEARN_version(raw_pangolin_result=second_line)
+            pangoLEARN_version: str = self.get_pangoLEARN_version(
+                raw_pangolin_result=second_line
+            )
             results[cust_sample_id]["pangolearn_version"] = pangoLEARN_version
             voc_strains: dict = self.identify_classifications()
             if pangolin_type in voc_strains["lineage"]:
@@ -176,14 +214,20 @@ class ParserNanopore:
             results[sample]["mutations"] = "-"
         return results
 
-    def parse_mutations(self, results: dict, resdir: str, limsid_to_sample: dict) -> dict:
+    def parse_mutations(
+        self, results: dict, resdir: str, limsid_to_sample: dict
+    ) -> dict:
         """If a mutation of interest is present in a sample it will be added to a dict"""
         mutations_of_interest: list = self.get_mutations_of_interest()
-        base_path = "/".join([resdir, "articNcovNanopore_Genotyping_typeVariants", "variants"])
+        base_path = "/".join(
+            [resdir, "articNcovNanopore_Genotyping_typeVariants", "variants"]
+        )
         results: dict = self.initiate_mutations_dict(results=results)
         for filename in os.listdir(base_path):
             abs_path = os.path.join(base_path, filename)
-            cust_sample_id: str = self.get_sample_id_from_filename(filename=filename, limsid_to_sample=limsid_to_sample)
+            cust_sample_id: str = self.get_sample_id_from_filename(
+                filename=filename, limsid_to_sample=limsid_to_sample
+            )
             with open(abs_path, "r") as variant_file:
                 next(variant_file)
                 for line in variant_file:
@@ -192,7 +236,12 @@ class ParserNanopore:
                         if results[cust_sample_id]["mutations"] == "-":
                             results[cust_sample_id]["mutations"] = split_on_comma[2]
                         else:
-                            results[cust_sample_id]["mutations"] = ";".join([results[cust_sample_id]["mutations"], split_on_comma[2]])
+                            results[cust_sample_id]["mutations"] = ";".join(
+                                [
+                                    results[cust_sample_id]["mutations"],
+                                    split_on_comma[2],
+                                ]
+                            )
         return results
 
     def collect_results(self, resdir: str) -> dict:
@@ -200,8 +249,16 @@ class ParserNanopore:
         parsed_config: dict = get_sarscov2_config(config=self.caseinfo)
         limsid_to_sample: dict = self.translate_limsids(parsed_config=parsed_config)
         results: dict = self.get_data_from_config(parsed_config=parsed_config)
-        results: dict = self.parse_assembly(results=results, resdir=resdir, limsid_to_sample=limsid_to_sample)
-        results: dict = self.calculate_coverage(results=results, resdir=resdir, limsid_to_sample=limsid_to_sample)
-        results: dict = self.parse_pangolin(results=results, limsid_to_sample=limsid_to_sample, resdir=resdir)
-        results: dict = self.parse_mutations(results=results, resdir=resdir, limsid_to_sample=limsid_to_sample)
+        results: dict = self.parse_assembly(
+            results=results, resdir=resdir, limsid_to_sample=limsid_to_sample
+        )
+        results: dict = self.calculate_coverage(
+            results=results, resdir=resdir, limsid_to_sample=limsid_to_sample
+        )
+        results: dict = self.parse_pangolin(
+            results=results, limsid_to_sample=limsid_to_sample, resdir=resdir
+        )
+        results: dict = self.parse_mutations(
+            results=results, resdir=resdir, limsid_to_sample=limsid_to_sample
+        )
         return results

--- a/mutant/modules/artic_nanopore/report.py
+++ b/mutant/modules/artic_nanopore/report.py
@@ -4,6 +4,7 @@
 
 from mutant.modules.generic_parser import get_sarscov2_config
 
+
 class ReportPrinterNanopore:
     def __init__(self, caseinfo: str, indir: str):
         self.casefile = caseinfo
@@ -17,35 +18,39 @@ class ReportPrinterNanopore:
         file_name_report = "_".join(["sars-cov-2", str(self.ticket), "results.csv"])
         result_file = "/".join([self.indir, file_name_report])
         with open(result_file, "a") as file_to_append:
-            header_results = ",".join([
-                "Sample",
-                "Selection",
-                "Region Code",
-                "Ticket",
-                "%N_bases",
-                "%10X_coverage",
-                "QC_pass",
-                "Lineage",
-                "PangoLEARN_version",
-                "VOC",
-                "Mutations\n"
-            ])
+            header_results = ",".join(
+                [
+                    "Sample",
+                    "Selection",
+                    "Region Code",
+                    "Ticket",
+                    "%N_bases",
+                    "%10X_coverage",
+                    "QC_pass",
+                    "Lineage",
+                    "PangoLEARN_version",
+                    "VOC",
+                    "Mutations\n",
+                ]
+            )
             file_to_append.write(header_results)
             samples = result.keys()
             for sample in samples:
-                line_to_append = "{0},{1},{2},{3},{4},{5},{6},{7},{8},{9},{10}{11}".format(
-                    sample,
-                    result[sample]["selection_criteria"],
-                    result[sample]["region_code"],
-                    self.ticket,
-                    result[sample]["fraction_n_bases"],
-                    result[sample]["pct_10x_coverage"],
-                    result[sample]["qc_pass"],
-                    result[sample]["pangolin_type"],
-                    result[sample]["pangolearn_version"],
-                    result[sample]["voc"],
-                    result[sample]["mutations"],
-                    "\n"
+                line_to_append = (
+                    "{0},{1},{2},{3},{4},{5},{6},{7},{8},{9},{10}{11}".format(
+                        sample,
+                        result[sample]["selection_criteria"],
+                        result[sample]["region_code"],
+                        self.ticket,
+                        result[sample]["fraction_n_bases"],
+                        result[sample]["pct_10x_coverage"],
+                        result[sample]["qc_pass"],
+                        result[sample]["pangolin_type"],
+                        result[sample]["pangolearn_version"],
+                        result[sample]["voc"],
+                        result[sample]["mutations"],
+                        "\n",
+                    )
                 )
                 file_to_append.write(line_to_append)
         file_to_append.close()

--- a/mutant/standalone/helper_scripts/get_data_from_ecdc.py
+++ b/mutant/standalone/helper_scripts/get_data_from_ecdc.py
@@ -39,7 +39,7 @@ with open(os.path.join(outdir, "classifications.csv"), "w") as class_outfile:
                 if "(" in mut:
                     mut = mut.split("(")[0]
                 if mut not in all_mutations:
-                  all_mutations.append(mut)
+                    all_mutations.append(mut)
 
             # Get data from variant column
             lineage = row.findAll("td")[1].getText().strip().replace(" ", "")

--- a/mutant/standalone/helper_scripts/get_data_from_ecdc_omicron.py
+++ b/mutant/standalone/helper_scripts/get_data_from_ecdc_omicron.py
@@ -47,7 +47,7 @@ with open(os.path.join(outdir, "classifications.csv"), "w") as class_outfile:
                 if "(" in mut:
                     mut = mut.split("(")[0]
                 if mut not in all_mutations:
-                  all_mutations.append(mut)
+                    all_mutations.append(mut)
 
             # Get data from variant column
             lineage = row.findAll("td")[1].getText().strip().replace(" ", "")
@@ -62,7 +62,7 @@ with open(os.path.join(outdir, "classifications.csv"), "w") as class_outfile:
                 class_lineage.append(lineage)
 
         # Add omicron data
-        if i==0:
+        if i == 0:
             class_lineage.append("B.1.1.529")
 
         # Output formatted lineages
@@ -74,9 +74,11 @@ with open(os.path.join(outdir, "classifications.csv"), "w") as class_outfile:
             classifications.writerow([lineage, spike, classtype[i]])
 
 # Add omicron mutations
-all_omicron_mutations = "A67V, Δ69-70, T95I, G142D, Δ143-145, Δ211-212, ins214EPE, G339D, S371L, S373P, S375F, K417N," \
-                       "N440K, G446S, S477N, T478K, E484A, Q493R, G496S, Q498R, N501Y, Y505H, T547K, D614G, H655Y," \
-                       "N679K, P681H, N764K, D796Y, N856K, Q954H, N969K, L981F".replace(" ", "").split(",")
+all_omicron_mutations = (
+    "A67V, Δ69-70, T95I, G142D, Δ143-145, Δ211-212, ins214EPE, G339D, S371L, S373P, S375F, K417N,"
+    "N440K, G446S, S477N, T478K, E484A, Q493R, G496S, Q498R, N501Y, Y505H, T547K, D614G, H655Y,"
+    "N679K, P681H, N764K, D796Y, N856K, Q954H, N969K, L981F".replace(" ", "").split(",")
+)
 for mut in all_omicron_mutations:
     if mut not in all_mutations:
         all_mutations.append(mut)


### PR DESCRIPTION
### The purpose of the code changes are as follows:
Since the customers will set the sample names on folders instead of keeping default "barcodeXX" names we will use the same `cg add external` dataflow as for illumina. Therefore we have to translate limsids instead of "barcodeXX" identifiers.

Also support is added for mutant to select the correct configuration with respect to sequencing platform and primer schema used.

### Preparations:

**How to prepare mutant for test**:
* `cd MUTANT`
* `bash mutant/standalone/deploy_hasta_update.sh stage <MUTANT_branch>`

**How to prepare cg for test**:
- `us`
- Paxa and update cg:
  - `paxa -u <user> -s hasta -r cg-stage`
  - `bash update-cg-stage.sh master`
- If needed, paxa and update servers:
  - `paxa -u <user> -s hasta -r servers-stage`
  - `bash update-servers-stage.sh <master/branch>`
  
### How to test:
Run in a tmux screen or similar if testing on a large dataset.

**Test with cg**:
- `us`
- `cg workflow mutant start maturejay`

### Expected outcome:
- [ ] Produced files contain expected values

### Review:
- [ ] Code reviewed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
