### PR TITLE
Variants nanopore

### DIFF
--- a/mutant/cli.py
+++ b/mutant/cli.py
@@ -106,11 +106,14 @@ def sarscov2(
             result: dict = parser.collect_results(
                 resdir=os.path.abspath(resdir), barcode_to_sampleid=barcode_to_sampleid
             )
+            variants: list = parser.collect_variants(
+                resdir=os.path.abspath(resdir), barcode_to_sampleid=barcode_to_sampleid
+            )
             report_printer = ReportPrinterNanopore(
                 caseinfo=config_case,
                 indir=os.path.abspath(resdir),
             )
-            report_printer.print_report(result=result)
+            report_printer.create_all_nanopore_files(result=result, variants=variants)
 
     else:
         # Report

--- a/mutant/modules/artic_nanopore/parser.py
+++ b/mutant/modules/artic_nanopore/parser.py
@@ -256,3 +256,26 @@ class ParserNanopore:
             results=results, resdir=resdir, barcode_to_sampleid=barcode_to_sampleid
         )
         return results
+
+    def extract_barcode_from_variant_file(self, filename: str) -> str:
+        prefix = filename.split("_")[2]
+        barcode = prefix.split(".")[0]
+        return barcode
+
+    def collect_variants(self, resdir: str, barcode_to_sampleid: dict) -> list:
+        variants_list = []
+        base_path = "/".join(
+            [resdir, "articNcovNanopore_Genotyping_typeVariants", "variants"]
+        )
+        for filename in os.listdir(base_path):
+            abs_path = os.path.join(base_path, filename)
+            with open(abs_path, "r") as variant_file:
+                next(variant_file)
+                for line in variant_file:
+                    barcode = self.extract_barcode_from_variant_file(filename=filename)
+                    line_except_sampleid = line.split(",")[1] + "," + line.split(",")[2]
+                    modified_line = (
+                        barcode_to_sampleid[barcode] + "," + line_except_sampleid
+                    )
+                    variants_list.append(modified_line)
+        return variants_list

--- a/mutant/modules/artic_nanopore/report.py
+++ b/mutant/modules/artic_nanopore/report.py
@@ -13,6 +13,28 @@ class ReportPrinterNanopore:
         self.ticket = self.caseinfo[0]["Customer_ID_project"]
         self.indir = indir
 
+    def create_all_nanopore_files(self, result: dict, variants: list):
+        self.print_report(result=result)
+        self.print_variants(variants=variants)
+
+    def print_variants(self, variants: list) -> None:
+        """Append data to the variant report"""
+        file_name_report = "_".join(["sars-cov-2", str(self.ticket), "variants.csv"])
+        variants_file = "/".join([self.indir, file_name_report])
+        with open(variants_file, "a") as file_to_append:
+            header_results = ",".join(
+                [
+                    "sampleID",
+                    "gene",
+                    "aa_var",
+                    "dna_var",
+                ]
+            )
+            file_to_append.write(header_results)
+            for line in variants:
+                file_to_append.write(line)
+        file_to_append.close()
+
     def print_report(self, result: dict) -> None:
         """Append results from the analysis to a report"""
         file_name_report = "_".join(["sars-cov-2", str(self.ticket), "results.csv"])

--- a/mutant/modules/artic_nanopore/report.py
+++ b/mutant/modules/artic_nanopore/report.py
@@ -27,12 +27,12 @@ class ReportPrinterNanopore:
                     "sampleID",
                     "gene",
                     "aa_var",
-                    "dna_var",
+                    "dna_var\n",
                 ]
             )
             file_to_append.write(header_results)
             for line in variants:
-                file_to_append.write(line)
+                file_to_append.write(line + "\n")
         file_to_append.close()
 
     def print_report(self, result: dict) -> None:


### PR DESCRIPTION
### The purpose of the code changes are as follows:
-  Print the variant file for nanopore analyses as it is printed for illunmina analyses

### Preparations:

**How to prepare mutant for test**:
* `cd MUTANT`
* `bash mutant/standalone/deploy_hasta_update.sh stage <MUTANT_branch>`

**How to prepare cg for test**:
- `us`
- Paxa and update cg:
  - `paxa -u <user> -s hasta -r cg-stage`
  - `bash update-cg-stage.sh master`
- If needed, paxa and update servers:
  - `paxa -u <user> -s hasta -r servers-stage`
  - `bash update-servers-stage.sh <master/branch>`
  
### How to test:
Run in a tmux screen or similar if testing on a large dataset.

**Test with cg**:
- `us`
- `cg workflow mutant start maturejay`

### Expected outcome:
- [ ] Produced files contain expected values

### Review:
- [ ] Code reviewed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
