### PR TITLE
Added nextclade summary parser

### DIFF
--- a/mutant/cli.py
+++ b/mutant/cli.py
@@ -253,22 +253,22 @@ def report(ctx):
 
 
 @report.command(name="sarscov2")
-@click.argument("input_folder")
 @click.option(
     "--config_artic",
     help="Custom artic configuration file",
 )
 @click.option("--config_case", help="Provided config for the case")
+@click.option("--fastq_dir", help="The fastq directory of the case")
 @click.option("--result_dir", help="The result directory for the case")
 @click.pass_context
 def sarscov2_report(
-    ctx, input_folder: str, config_artic: str, config_case: str, result_dir: str
+    ctx, config_artic: str, config_case: str, fastq_dir: str, result_dir: str
 ):
     """Generate all sarscov2 output files"""
     report = ReportSC2(
         caseinfo=config_case,
         indir=os.path.abspath(result_dir),
-        fastq_dir=os.path.abspath(input_folder),
+        fastq_dir=os.path.abspath(fastq_dir),
         config_artic=config_artic,
         timestamp=TIMESTAMP,
     )

--- a/mutant/cli.py
+++ b/mutant/cli.py
@@ -264,7 +264,7 @@ def report(ctx):
 def sarscov2_report(
     ctx, input_folder: str, config_artic: str, config_case: str, result_dir: str
 ):
-    """# Generate all sarscov2 output files"""
+    """Generate all sarscov2 output files"""
     report = ReportSC2(
         caseinfo=config_case,
         indir=os.path.abspath(result_dir),

--- a/mutant/cli.py
+++ b/mutant/cli.py
@@ -63,7 +63,6 @@ def sarscov2(
     profiles,
     nanopore,
 ):
-
     if not config_case:
         log.debug("No case config given, mutant needs a case config to run analysis")
 
@@ -245,3 +244,32 @@ def create_images(ctx):
     proc = subprocess.Popen(cmd.split())
     out, err = proc.communicate()
     os.chdir(bdir)
+
+
+@root.group()
+@click.pass_context
+def report(ctx):
+    pass
+
+
+@report.command(name="sarscov2")
+@click.argument("input_folder")
+@click.option(
+    "--config_artic",
+    help="Custom artic configuration file",
+)
+@click.option("--config_case", help="Provided config for the case")
+@click.option("--result_dir", help="The result directory for the case")
+@click.pass_context
+def sarscov2_report(
+    ctx, input_folder: str, config_artic: str, config_case: str, result_dir: str
+):
+    """# Generate all sarscov2 output files"""
+    report = ReportSC2(
+        caseinfo=config_case,
+        indir=os.path.abspath(result_dir),
+        fastq_dir=os.path.abspath(input_folder),
+        config_artic=config_artic,
+        timestamp=TIMESTAMP,
+    )
+    report.create_all_files()

--- a/mutant/cli.py
+++ b/mutant/cli.py
@@ -41,7 +41,7 @@ def analyse(ctx):
 @click.option(
     "--config_mutant",
     help="General configuration file for MUTANT",
-    default="{}/config/hasta/mutant.json".format(WD),
+    default=f"{WD}/config/hasta/mutant.json",
 )
 @click.option(
     "--outdir", help="Output folder to override general configutations", default=""
@@ -68,12 +68,11 @@ def sarscov2(
 
     caseinfo = get_json(config_case)
     caseID = caseinfo[0]["case_ID"]
-    prefix = "{}_{}".format(caseID, TIMESTAMP)
+    prefix = f"{caseID}_{TIMESTAMP}"
 
     primer_json = caseinfo[0]["primer"].replace(" ", "_")
     if not config_artic:
-        primer_config = "{}/config/hasta/" + primer_json.lower() + ".json"
-        config_artic = primer_config.format(WD)
+        config_artic = f"{WD}/config/hasta/" + primer_json.lower() + ".json"
 
     if "nanopore" in primer_json.lower():
         nanopore = True
@@ -155,7 +154,7 @@ def sarscov2(ctx):
 @click.option(
     "--config_artic",
     help="Custom artic configuration file",
-    default="{}/config/hasta/default_config.json".format(WD),
+    default=f"{WD}/config/hasta/default_config.json",
 )
 @click.option("--fastq_folder", help="Sequence data folder for the case", required=True)
 @click.option("--config_case", help="Provided config for the case", required=True)
@@ -190,7 +189,7 @@ def postproc(ctx, input_folder, config_artic, fastq_folder, config_case):
 @click.option(
     "--config_artic",
     help="Custom artic configuration file",
-    default="{}/config/hasta/default_config.json".format(WD),
+    default=f"{WD}/config/hasta/default_config.json",
 )
 @click.option("--config_case", help="Provided config for the case", required=True)
 @click.pass_context
@@ -221,14 +220,10 @@ def rename(ctx, input_folder, config_artic, config_case):
 def concatenate(ctx, input_folder, app_tag, date):
     """Concatenates fastq files if needed"""
     if date:
-        cmd = "python {0}/standalone/concatenate.py --input_folder {1} --app_tag {2} --date {3}".format(
-            WD, input_folder, app_tag, date
-        )
+        cmd = f"python {WD}/standalone/concatenate.py --input_folder {input_folder} --app_tag {app_tag} --date {date}"
     else:
-        cmd = "python {0}/standalone/concatenate.py --input_folder {1} --app_tag {2}".format(
-            WD, input_folder, app_tag
-        )
-    log.debug("Command ran: {}".format(cmd))
+        cmd = f"python {WD}/standalone/concatenate.py --input_folder {input_folder} --app_tag {app_tag}"
+    log.debug(f"Command ran: {cmd}")
     proc = subprocess.Popen(cmd.split())
     out, err = proc.communicate()
 
@@ -238,9 +233,9 @@ def concatenate(ctx, input_folder, app_tag, date):
 def create_images(ctx):
     """Builds the sarscov2 pipeline images"""
     bdir = os.getcwd()
-    os.chdir("{0}/externals/gms-artic".format(WD))
+    os.chdir(f"{WD}/externals/gms-artic")
     cmd = "bash scripts/build_singularity_containers.sh && chmod 0777 *.sif"
-    log.debug("Command ran: {}".format(cmd))
+    log.debug(f"Command ran: {cmd}")
     proc = subprocess.Popen(cmd.split())
     out, err = proc.communicate()
     os.chdir(bdir)

--- a/mutant/constants/artic.py
+++ b/mutant/constants/artic.py
@@ -67,4 +67,11 @@ MULTIQC_TO_VOGUE = {
 }
 
 # Header for nextclade concatenation file
-NEXTCLADE_HEADER = ["seqName","clade","Nextclade_pango","partiallyAliased"]
+NEXTCLADE_HEADER = [
+    "seqName",
+    "clade",
+    "Nextclade_pango",
+    "partiallyAliased",
+    "immune_escape",
+    "ace2_binding",
+]

--- a/mutant/constants/artic.py
+++ b/mutant/constants/artic.py
@@ -7,6 +7,7 @@ ILLUMINA_FILES_CASE = {
     "vogue-metrics": "{resdir}/{case}_metrics_deliverables.yaml",
     "results-file": "{resdir}/sars-cov-2_{ticket}_results.csv",
     "versions-file": "{resdir}/ncovIllumina_sequenceAnalysis_versions/*_versions.csv",
+    "nextclade_file": "{resdir}/ncovIllumina_sequenceAnalysis_nextclade/nextclade_summary.csv",
 }
 
 # GMS-Artic and MUTANT output files for Nanopore
@@ -64,3 +65,6 @@ MULTIQC_TO_VOGUE = {
         },
     },
 }
+
+# Header for nextclade concatenation file
+NEXTCLADE_HEADER = ["seqName","clade","Nextclade_pango","partiallyAliased"]

--- a/mutant/constants/artic.py
+++ b/mutant/constants/artic.py
@@ -7,7 +7,7 @@ ILLUMINA_FILES_CASE = {
     "vogue-metrics": "{resdir}/{case}_metrics_deliverables.yaml",
     "results-file": "{resdir}/sars-cov-2_{ticket}_results.csv",
     "versions-file": "{resdir}/ncovIllumina_sequenceAnalysis_versions/*_versions.csv",
-    "nextclade_file": "{resdir}/ncovIllumina_sequenceAnalysis_nextclade/nextclade_summary.csv",
+    "nextclade_file": "{resdir}/nextclade_summary.csv",
 }
 
 # GMS-Artic and MUTANT output files for Nanopore

--- a/mutant/modules/artic_illumina/parser.py
+++ b/mutant/modules/artic_illumina/parser.py
@@ -111,16 +111,16 @@ def get_artic_results(indir) -> dict:
     """Parse artic output directory for analysis results. Returns dictionary data object"""
 
     voc_pos = range(475, 486)
-    muts = pandas.read_csv("{0}/standalone/spike_mutations.csv".format(WD), sep=",")
+    muts = pandas.read_csv(f"{WD}/standalone/spike_mutations.csv")
     # Magical unpacking into single list
     voc_pos_aa = sum(muts.values.tolist(), [])
 
-    classifications_path = "{0}/standalone/classifications.csv".format(WD)
+    classifications_path = f"{WD}/standalone/classifications.csv"
     voc_strains: dict = parse_classifications(csv_path=classifications_path)
 
     artic_data = dict()
     var_all = dict()
-    
+
     var_voc = dict()
 
     # Files of interest. ONLY ADD TO END OF THIS LIST
@@ -135,12 +135,10 @@ def get_artic_results(indir) -> dict:
             if len(hits) == 0:
                 raise Exception("File not found")
             if len(hits) > 1:
-                print(
-                    "Multiple hits for {0}/{1}, picking {2}".format(indir, f, hits[0])
-                )
+                print(f"Multiple hits for {indir}/{f}, picking {hits[0]}")
             paths.append(hits[0])
         except Exception as e:
-            print("Unable to find {0} in {1} ({2})".format(f, indir, e))
+            print(f"Unable to find {f} in {indir} ({e})")
             sys.exit(-1)
 
     # Parse qc report data
@@ -176,8 +174,8 @@ def get_artic_results(indir) -> dict:
                 append_dict(var_all, sample, variant)
 
     # Parse Pangolin report data
-    pangodir = "{0}/ncovIllumina_sequenceAnalysis_pangolinTyping".format(indir)
-    pangolins = glob.glob("{0}/*.pangolin.csv".format(pangodir))
+    pangodir = f"{indir}/ncovIllumina_sequenceAnalysis_pangolinTyping"
+    pangolins = glob.glob(f"{pangodir}/*.pangolin.csv")
     for path in pangolins:
         with open(path) as f:
             content = csv.reader(f)
@@ -242,9 +240,7 @@ class NextcladeHeaderError(Exception):
     """
 
 
-def check_nextclade_header(
-    header_index: Dict[str, int], nextclade_header: List[str]
-) -> None:
+def check_nextclade_header(header_index: Dict[str, int], nextclade_header: List[str]) -> None:
     """
     Function to check if all headers are actually in the files
     """
@@ -255,7 +251,7 @@ def check_nextclade_header(
             number_of_matches += 1
 
     if number_of_matches != len(nextclade_header):
-        message = f"Header error: a file in this batch does not contain all headers for wanted values or the headers are in wrong order"
+        message = "Header error: a file in this batch does not contain all headers for wanted values or the headers are in wrong order"
         raise NextcladeHeaderError(message)
 
 
@@ -263,16 +259,12 @@ def parse_nextclade_files(result_dir: str) -> List[dict]:
     """
     Function to iterate over all files in ncovIllumina_sequenceAnalysis_nextclade directory
     """
-    nextclade_results: Path = Path(
-        result_dir, "ncovIllumina_sequenceAnalysis_nextclade"
-    )
+    nextclade_results: Path = Path(result_dir, "ncovIllumina_sequenceAnalysis_nextclade")
     nextclade_content: List[dict] = []
     for nextclade_filename in nextclade_results.iterdir():
         # checking if it is a file
         if nextclade_filename.is_file():
-            nextclade_content.append(
-                parse_nextclade_content(nextclade_filename=nextclade_filename)
-            )
+            nextclade_content.append(parse_nextclade_content(nextclade_filename=nextclade_filename))
     return nextclade_content
 
 
@@ -295,9 +287,7 @@ def parse_nextclade_content(nextclade_filename: Path) -> Dict[str, str]:
         header_index: Dict[str, int] = get_nextclade_header(header_line=header_line)
 
         # raise data error if header is not as nextclade_header
-        check_nextclade_header(
-            header_index=header_index, nextclade_header=NEXTCLADE_HEADER
-        )
+        check_nextclade_header(header_index=header_index, nextclade_header=NEXTCLADE_HEADER)
 
         # get all values on second line
         value_list = nf.readline().split("\t")
@@ -305,7 +295,5 @@ def parse_nextclade_content(nextclade_filename: Path) -> Dict[str, str]:
         # save the values corresponding to header
         header_and_values_dict: Dict[str, str] = {}
         for column, position in header_index.items():
-            header_and_values_dict[column] = (
-                value_list[position] if value_list[position] else "-"
-            )
+            header_and_values_dict[column] = value_list[position] if value_list[position] else "-"
     return header_and_values_dict

--- a/mutant/modules/artic_illumina/parser.py
+++ b/mutant/modules/artic_illumina/parser.py
@@ -120,6 +120,7 @@ def get_artic_results(indir) -> dict:
 
     artic_data = dict()
     var_all = dict()
+    
     var_voc = dict()
 
     # Files of interest. ONLY ADD TO END OF THIS LIST

--- a/mutant/modules/artic_illumina/report.py
+++ b/mutant/modules/artic_illumina/report.py
@@ -349,6 +349,6 @@ class ReportSC2:
                 content_list: List[str] = []
                 for elem in NEXTCLADE_HEADER:
                     content_list.append(content[elem])
-                    samplename = content_list[0].split(".")[0].split("_")[3]
-                    content_list[0] = samplename
+                samplename = content_list[0].split(".")[0].split("_")[3]
+                content_list[0] = samplename
                 fp.write('\t'.join(content_list) + '\n')

--- a/mutant/modules/artic_illumina/report.py
+++ b/mutant/modules/artic_illumina/report.py
@@ -349,4 +349,6 @@ class ReportSC2:
                 content_list: List[str] = []
                 for elem in NEXTCLADE_HEADER:
                     content_list.append(content[elem])
+                    samplename = content_list[0].split(".")[0].split("_")[3]
+                    content_list[0] = samplename
                 fp.write('\t'.join(content_list) + '\n')

--- a/mutant/modules/artic_illumina/report.py
+++ b/mutant/modules/artic_illumina/report.py
@@ -49,10 +49,8 @@ class ReportSC2:
         self.fastq_dir = fastq_dir
         self.filepaths = get_results_paths(self.indir, self.case, self.ticket, False)
         self.articdata = dict()
-        self.consensus_path = "{0}/ncovIllumina_sequenceAnalysis_makeConsensus".format(
-            self.indir
-        )
-        self.consensus_target_files = "{0}/*.consensus.fa".format(self.consensus_path)
+        self.consensus_path = f"{self.indir}/ncovIllumina_sequenceAnalysis_makeConsensus"
+        self.consensus_target_files = f"{self.consensus_path}/*.consensus.fa"
 
     def create_all_files(self):
         generic_reporter = GenericReporter(
@@ -67,10 +65,8 @@ class ReportSC2:
         self.create_concat_pangolin()
         self.create_concat_pangolin_fohm()
         # This works off concat pango and needs to occur after
-        generic_reporter.create_concat_consensus(
-            target_files=self.consensus_target_files
-        )
-        generic_reporter.create_deliveryfile(fastq_dir=self.fastq_dir)
+        generic_reporter.create_concat_consensus(target_files=self.consensus_target_files)
+        generic_reporter.create_delivery_metrics(fastq_dir=self.fastq_dir)
         self.create_vogue_metrics_file()
         self.create_fohm_csv()
         self.create_sarscov2_resultfile()
@@ -112,9 +108,7 @@ class ReportSC2:
         out_yaml = {"metrics": []}
         # Get multiqc-data
         out_yaml["metrics"].extend(
-            get_vogue_multiqc_data(
-                self.filepaths[self.case]["multiqc-json"], self.caseinfo
-            )
+            get_vogue_multiqc_data(self.filepaths[self.case]["multiqc-json"], self.caseinfo)
         )
         # Add info about failed/passed QC
         for record in self.caseinfo:
@@ -122,9 +116,7 @@ class ReportSC2:
                 sample_yaml = {
                     "header": "~",
                     "id": record["CG_ID_sample"],
-                    "input": os.path.basename(
-                        self.filepaths[self.case]["results-file"]
-                    ),
+                    "input": os.path.basename(self.filepaths[self.case]["results-file"]),
                     "name": "passed-qc",
                     "step": "QC-threshold",
                     "value": self.articdata[record["Customer_ID_sample"]]["qc"],
@@ -134,9 +126,7 @@ class ReportSC2:
                 sample_yaml = {
                     "header": "~",
                     "id": record["CG_ID_sample"],
-                    "input": os.path.basename(
-                        self.filepaths[self.case]["results-file"]
-                    ),
+                    "input": os.path.basename(self.filepaths[self.case]["results-file"]),
                     "name": "passed-qc",
                     "step": "QC-threshold",
                     "value": "FALSE",
@@ -149,9 +139,9 @@ class ReportSC2:
     def create_concat_pangolin(self):
         """Concatenate pangolin results"""
 
-        indir = "{0}/ncovIllumina_sequenceAnalysis_pangolinTyping".format(self.indir)
-        concatfile = "{0}/{1}.pangolin.csv".format(self.indir, self.ticket)
-        pangolins = glob.glob("{0}/*.pangolin.csv".format(indir))
+        indir = f"{self.indir}/ncovIllumina_sequenceAnalysis_pangolinTyping"
+        concatfile = f"{self.indir}/{self.ticket}.pangolin.csv"
+        pangolins = glob.glob(f"{indir}/*.pangolin.csv")
         # Copy header
         header = read_filelines(pangolins[0])[0]
         with open(concatfile, "w") as concat:
@@ -161,12 +151,10 @@ class ReportSC2:
                 data = read_filelines(pango)[1:]
                 for line in data:
                     # Use sample name at taxon field
-                    taxon_regex = "(\w+)_(\w+)_(\w+)_(?P<name>\w+).(\S+)"
+                    taxon_regex = r"(\w+)_(\w+)_(\w+)_(?P<name>\w+).(\S+)"
                     sample, subs = re.subn(taxon_regex, r"\g<name>", line.split(",")[0])
                     if subs == 0:
-                        print(
-                            "Unable to rename taxon - using original: {}".format(pango)
-                        )
+                        print(f"Unable to rename taxon - using original: {pango}")
                     else:
                         line = sample + line[line.find(",") :]
                     concat.write(line)
@@ -174,11 +162,11 @@ class ReportSC2:
     def create_concat_pangolin_fohm(self):
         """Concatenate pangolin results and format for fohm"""
 
-        indir = "{0}/ncovIllumina_sequenceAnalysis_pangolinTyping".format(self.indir)
-        concatfile = "{0}/{1}_{2}_pangolin_classification_format4.txt".format(
-            self.indir, self.ticket, str(date.today())
+        indir = f"{self.indir}/ncovIllumina_sequenceAnalysis_pangolinTyping"
+        concatfile = (
+            f"{self.indir}/{self.ticket}_{str(date.today())}_pangolin_classification_format4.txt"
         )
-        pangolins = glob.glob("{0}/*.pangolin.csv".format(indir))
+        pangolins = glob.glob(f"{indir}/*.pangolin.csv")
         # Copy header
         header = read_filelines(pangolins[0])[0]
         with open(concatfile, "w") as concat:
@@ -238,10 +226,10 @@ class ReportSC2:
                 ms = "INCONSISTENT"
 
         with open(propfile, "w") as prop:
-            prop.write("instrument={}\n".format(ms))
-            prop.write("plattform={}\n".format(plfrm))
-            prop.write("biblioteksmetod={}\n".format(ml))
-            prop.write("lanes={}\n".format(lanes))
+            prop.write(f"instrument={ms}\n")
+            prop.write(f"plattform={plfrm}\n")
+            prop.write(f"biblioteksmetod={ml}\n")
+            prop.write(f"lanes={lanes}\n")
 
     def create_sarscov2_resultfile(self):
         """Write summary csv report of Artic and Pangolin results"""
@@ -291,10 +279,7 @@ class ReportSC2:
                         qc_status = data["qc"]
                 if "lineage" in data:
                     lineage = data["lineage"]
-                if (
-                    "pangolin_data_version" in data
-                    and data["pangolin_data_version"] != ""
-                ):
+                if "pangolin_data_version" in data and data["pangolin_data_version"] != "":
                     verzion = data["pangolin_data_version"]
                 if "VOC" in data:
                     vocs = data["VOC"]
@@ -323,9 +308,8 @@ class ReportSC2:
 
         indir = self.indir
         ticket = self.ticket
-        today = self.today
         varRep = glob.glob(os.path.join(indir, "*variant_summary.csv"))[0]
-        varout = os.path.join(indir, "sars-cov-2_{}_variants.csv".format(ticket, today))
+        varout = os.path.join(indir, f"sars-cov-2_{ticket}_variants.csv")
         if os.stat(varRep).st_size != 0:
             with open(varRep) as f, open(varout, mode="w") as out:
                 variants = f.readlines()
@@ -338,7 +322,7 @@ class ReportSC2:
             try:
                 open(varout, "a").close()
             except Exception as e:
-                print("Failed creating file {}\n{}".format(varout, e))
+                print(f"Failed creating file {varout}\n{e}")
 
     def create_jsonfile(self):
         """Output all result data in a json format for easy parsing"""
@@ -347,9 +331,7 @@ class ReportSC2:
             print("No artic results loaded. Quitting create_jsonfile")
             sys.exit(-1)
 
-        with open(
-            "{}/{}_artic.json".format(self.indir, self.ticket, self.today), "w"
-        ) as outfile:
+        with open(f"{self.indir}/{self.ticket}_{self.today}_artic.json", "w") as outfile:
             json.dump(self.articdata, outfile)
 
     def create_nextclade_summary_file(self):

--- a/mutant/modules/artic_illumina/report.py
+++ b/mutant/modules/artic_illumina/report.py
@@ -1,7 +1,5 @@
 """ This class creates reports. Specifically it acts on the sarscov2 pipeline,
     and creates report files for Clinical Genomics Infrastructure
-
-    By: Isak Sylvin & Tanja Normark
 """
 import os
 import sys
@@ -188,7 +186,7 @@ class ReportSC2:
 
         sumfile = os.path.join(
             self.indir,
-            "{}_komplettering.csv".format(self.ticket),
+            f"{self.ticket}_komplettering.csv",
         )
         with open(sumfile, "w") as out:
             summary = csv.writer(out)

--- a/mutant/modules/artic_illumina/start.py
+++ b/mutant/modules/artic_illumina/start.py
@@ -2,18 +2,13 @@
     and creates a deliverables file for Clinical Genomics Infrastructure"""
 
 import os
-import sys
-import click
-import json
 import subprocess
-from mutant import version, log
+from mutant import log
 from mutant.modules.generic_parser import get_json
 
 
 class RunSC2:
-    def __init__(
-        self, input_folder, caseID, prefix, profiles, timestamp, WD, config_artic=""
-    ):
+    def __init__(self, input_folder, caseID, prefix, profiles, timestamp, WD, config_artic=""):
         self.fastq = input_folder
         self.timestamp = timestamp
         self.WD = WD
@@ -23,7 +18,6 @@ class RunSC2:
         self.profiles = profiles
 
     def get_results_dir(self, config, outdir):
-
         """Return result output directory"""
 
         if outdir != "":
@@ -33,7 +27,7 @@ class RunSC2:
             resdir = os.path.abspath(
                 os.path.join(
                     general_config["SARS-CoV-2"]["folders"]["results"],
-                    "{}_{}".format(self.case, self.timestamp),
+                    f"{self.case}_{self.timestamp}",
                 )
             )
         else:
@@ -41,40 +35,29 @@ class RunSC2:
         return resdir
 
     def run_case(self, resdir, nanopore):
-
         """Run SARS-CoV-2 analysis"""
 
-        resultsline = "--outdir {}".format(resdir)
-        workline = "-work-dir {}".format(os.path.join(resdir, "work"))
+        resultsline = f"--outdir {resdir}"
+        workline = f"-work-dir {os.path.join(resdir, 'work')}"
         nflog = os.path.join(resdir, "nextflow.log")
         confline = ""
         if self.config_artic != "":
-            confline = "-C {0}".format(self.config_artic)
+            confline = f"-C {self.config_artic}"
 
         if nanopore:
-            cmd = "nextflow {0} -log {1} run {2} {3}/externals/gms-artic/main.nf -profile {4} --medaka --prefix {5} --basecalled_fastq {6} {7}".format(
-                confline,
-                nflog,
-                workline,
-                self.WD,
-                self.profiles,
-                self.prefix,
-                self.fastq,
-                resultsline,
+            cmd = (
+                f"nextflow {confline} -log {nflog} run {workline} "
+                f"{self.WD}/externals/gms-artic/main.nf -profile {self.profiles} --medaka "
+                f"--prefix {self.prefix} --basecalled_fastq {self.fastq} {resultsline}"
             )
         else:
-            cmd = "nextflow {0} -log {1} run {2} {3}/externals/gms-artic/main.nf -profile {4} --illumina --prefix {5} --directory {6} {7}".format(
-                confline,
-                nflog,
-                workline,
-                self.WD,
-                self.profiles,
-                self.prefix,
-                self.fastq,
-                resultsline,
+            cmd = (
+                f"nextflow {confline} -log {nflog} run {workline} "
+                f"{self.WD}/externals/gms-artic/main.nf -profile {self.profiles} --illumina "
+                f"--prefix {self.prefix} --directory {self.fastq} {resultsline}"
             )
 
-        log.debug("Command ran: {}".format(cmd))
+        log.debug(f"Command ran: {cmd}")
         proc = subprocess.Popen(cmd.split())
         out, err = proc.communicate()
         log.info(out)

--- a/mutant/modules/artic_nanopore/parser.py
+++ b/mutant/modules/artic_nanopore/parser.py
@@ -32,9 +32,7 @@ def get_data_from_config(parsed_config: dict) -> dict:
     for sample in parsed_config:
         cust_sample_id = sample["Customer_ID_sample"]
         data_to_report[cust_sample_id] = {}
-        data_to_report[cust_sample_id]["selection_criteria"] = sample[
-            "selection_criteria"
-        ]
+        data_to_report[cust_sample_id]["selection_criteria"] = sample["selection_criteria"]
         data_to_report[cust_sample_id]["region_code"] = sample["region_code"]
     return data_to_report
 
@@ -54,9 +52,7 @@ def get_fraction_n(input_file: str) -> float:
 
 def parse_assembly(results: dict, resdir: str, barcode_to_sampleid: dict) -> dict:
     """Collects data by parsing the assembly"""
-    base_path = "/".join(
-        [resdir, "articNcovNanopore_sequenceAnalysisMedaka_articMinIONMedaka"]
-    )
+    base_path = "/".join([resdir, "articNcovNanopore_sequenceAnalysisMedaka_articMinIONMedaka"])
     for filename in os.listdir(base_path):
         if filename.endswith(".consensus.fasta"):
             abs_path = os.path.join(base_path, filename)
@@ -98,34 +94,23 @@ def initiate_coverage_stats_list(file_path: str) -> list:
 
 def calculate_coverage(results: dict, resdir: str, barcode_to_sampleid: dict) -> dict:
     """Collects data for the fraction of each assembly that got 10x coverage or more"""
-    base_path = "/".join(
-        [resdir, "articNcovNanopore_sequenceAnalysisMedaka_articMinIONMedaka/"]
-    )
+    base_path = "/".join([resdir, "articNcovNanopore_sequenceAnalysisMedaka_articMinIONMedaka/"])
     for barcode in barcode_to_sampleid:
-        coverage_files_paths: list = get_depth_files_paths(
-            barcode=barcode, base_path=base_path
-        )
-        coverage_stats: list = initiate_coverage_stats_list(
-            file_path=coverage_files_paths[0]
-        )
+        coverage_files_paths: list = get_depth_files_paths(barcode=barcode, base_path=base_path)
+        coverage_stats: list = initiate_coverage_stats_list(file_path=coverage_files_paths[0])
         with open(coverage_files_paths[1], "r") as file2:
             for line in file2:
                 stripped_line = line.strip()
                 columns: list = stripped_line.split("\t")
                 coverage_stats[int(columns[2])] += int(columns[3])
-        bases_w_10x_cov_or_more: int = count_bases_w_10x_cov_or_more(
-            coverage_stats=coverage_stats
-        )
+        bases_w_10x_cov_or_more: int = count_bases_w_10x_cov_or_more(coverage_stats=coverage_stats)
         percentage_equal_or_greater_than_10 = round(
             (bases_w_10x_cov_or_more / len(coverage_stats)) * 100, 2
         )
         results[barcode_to_sampleid[barcode]][
             "pct_10x_coverage"
         ] = percentage_equal_or_greater_than_10
-        if (
-            percentage_equal_or_greater_than_10
-            >= QC_PASS_THRESHOLD_COVERAGE_10X_OR_HIGHER
-        ):
+        if percentage_equal_or_greater_than_10 >= QC_PASS_THRESHOLD_COVERAGE_10X_OR_HIGHER:
             results[barcode_to_sampleid[barcode]]["qc_pass"] = "TRUE"
         else:
             results[barcode_to_sampleid[barcode]]["qc_pass"] = "FALSE"
@@ -148,16 +133,14 @@ def get_pango_version(raw_pangolin_result: str) -> str:
 
 def identify_classifications() -> dict:
     """Parse which lineages are classified as VOC/VOI etc"""
-    classifications_path = "{0}/standalone/classifications.csv".format(WD)
+    classifications_path = f"{WD}/standalone/classifications.csv"
     voc_strains: dict = parse_classifications(csv_path=classifications_path)
     return voc_strains
 
 
 def parse_pangolin(results: dict, barcode_to_sampleid: dict, resdir: str) -> dict:
     """Collect data for pangolin types"""
-    base_path = "/".join(
-        [resdir, "articNcovNanopore_sequenceAnalysisMedaka_pangolinTyping"]
-    )
+    base_path = "/".join([resdir, "articNcovNanopore_sequenceAnalysisMedaka_pangolinTyping"])
     for filename in os.listdir(base_path):
         abs_path = os.path.join(base_path, filename)
         second_line: str = get_line(filename=abs_path, line_index_of_interest=1)
@@ -179,7 +162,7 @@ def parse_pangolin(results: dict, barcode_to_sampleid: dict, resdir: str) -> dic
 
 def get_mutations_of_interest() -> list:
     """Collects data for mutations of interest into a list"""
-    mutations_of_interest = "{0}/standalone/spike_mutations.csv".format(WD)
+    mutations_of_interest = f"{WD}/standalone/spike_mutations.csv"
     mutations_list = []
     with open(mutations_of_interest, "r") as csv:
         next(csv)
@@ -210,9 +193,7 @@ def initiate_mutations_dict(results: dict) -> dict:
 def parse_mutations(results: dict, resdir: str, barcode_to_sampleid: dict) -> dict:
     """If a mutation of interest is present in a sample it will be added to a dict"""
     mutations_of_interest: list = get_mutations_of_interest()
-    base_path = "/".join(
-        [resdir, "articNcovNanopore_Genotyping_typeVariants", "variants"]
-    )
+    base_path = "/".join([resdir, "articNcovNanopore_Genotyping_typeVariants", "variants"])
     results: dict = initiate_mutations_dict(results=results)
     for filename in os.listdir(base_path):
         abs_path = os.path.join(base_path, filename)
@@ -263,9 +244,7 @@ def extract_barcode_from_variant_file(filename: str) -> str:
 
 def collect_variants(resdir: str, barcode_to_sampleid: dict) -> list:
     variants_list = []
-    base_path = "/".join(
-        [resdir, "articNcovNanopore_Genotyping_typeVariants", "variants"]
-    )
+    base_path = "/".join([resdir, "articNcovNanopore_Genotyping_typeVariants", "variants"])
     for filename in os.listdir(base_path):
         abs_path = os.path.join(base_path, filename)
         with open(abs_path, "r") as variant_file:
@@ -273,8 +252,6 @@ def collect_variants(resdir: str, barcode_to_sampleid: dict) -> list:
             for line in variant_file:
                 barcode = extract_barcode_from_variant_file(filename=filename)
                 line_except_sampleid = line.split(",")[1] + "," + line.split(",")[2]
-                modified_line = (
-                    barcode_to_sampleid[barcode] + "," + line_except_sampleid
-                )
+                modified_line = barcode_to_sampleid[barcode] + "," + line_except_sampleid
                 variants_list.append(modified_line)
     return variants_list

--- a/mutant/modules/artic_nanopore/report.py
+++ b/mutant/modules/artic_nanopore/report.py
@@ -12,25 +12,19 @@ from mutant.modules.generic_reporter import GenericReporter
 
 
 class ReportPrinterNanopore:
-    def __init__(
-        self, caseinfo: str, indir: str, barcode_to_sampleid: dict, config_artic: str
-    ):
+    def __init__(self, caseinfo: str, indir: str, barcode_to_sampleid: dict, config_artic: str):
         self.casefile = caseinfo
         self.caseinfo = get_sarscov2_config(self.casefile)
         self.case = self.caseinfo[0]["case_ID"]
         self.ticket = self.caseinfo[0]["Customer_ID_project"]
         self.indir = indir
-        self.fastq_dir = "{0}/../fastq".format(self.indir)
+        self.fastq_dir = f"{self.indir}/../fastq"
         self.config_artic = config_artic
         self.barcode_to_sampleid = barcode_to_sampleid
         self.consensus_path = (
-            "{0}/articNcovNanopore_sequenceAnalysisMedaka_articMinIONMedaka".format(
-                self.indir
-            )
+            f"{self.indir}/articNcovNanopore_sequenceAnalysisMedaka_articMinIONMedaka"
         )
-        self.consensus_target_files = "{0}/*.consensus.fasta".format(
-            self.consensus_path
-        )
+        self.consensus_target_files = f"{self.consensus_path}/*.consensus.fasta"
 
     def create_all_nanopore_files(self):
         result: dict = collect_results(
@@ -53,10 +47,8 @@ class ReportPrinterNanopore:
         generic_reporter.create_trailblazer_config()
         self.create_concat_pangolin()
         self.create_concat_pangolin_fohm(result=result)
-        generic_reporter.create_concat_consensus(
-            target_files=self.consensus_target_files
-        )
-        generic_reporter.create_deliveryfile(fastq_dir=self.fastq_dir)
+        generic_reporter.create_concat_consensus(target_files=self.consensus_target_files)
+        generic_reporter.create_delivery_metrics(fastq_dir=self.fastq_dir)
         self.create_fohm_csv(result=result)
         self.create_instrument_properties()
 
@@ -73,7 +65,7 @@ class ReportPrinterNanopore:
         """Creates a summary file for FoHMs additional info"""
         sumfile = os.path.join(
             self.indir,
-            "{}_komplettering.csv".format(self.ticket),
+            f"{self.ticket}_komplettering.csv",
         )
         with open(sumfile, "w") as out:
             summary = csv.writer(out)
@@ -126,20 +118,17 @@ class ReportPrinterNanopore:
             samples = result.keys()
             for sample in samples:
                 line_to_append = (
-                    "{0},{1},{2},{3},{4},{5},{6},{7},{8},{9},{10}{11}".format(
-                        sample,
-                        result[sample]["selection_criteria"],
-                        result[sample]["region_code"],
-                        self.ticket,
-                        result[sample]["fraction_n_bases"],
-                        result[sample]["pct_10x_coverage"],
-                        result[sample]["qc_pass"],
-                        result[sample]["pangolin_type"],
-                        result[sample]["pangolin_data_version"],
-                        result[sample]["voc"],
-                        result[sample]["mutations"],
-                        "\n",
-                    )
+                    f"{sample},"
+                    f"{result[sample]['selection_criteria']},"
+                    f"{result[sample]['region_code']},"
+                    f"{self.ticket},"
+                    f"{result[sample]['fraction_n_bases']},"
+                    f"{result[sample]['pct_10x_coverage']},"
+                    f"{result[sample]['qc_pass']},"
+                    f"{result[sample]['pangolin_type']},"
+                    f"{result[sample]['pangolin_data_version']},"
+                    f"{result[sample]['voc']},"
+                    f"{result[sample]['mutations']}\n"
                 )
                 file_to_append.write(line_to_append)
         file_to_append.close()
@@ -152,11 +141,9 @@ class ReportPrinterNanopore:
 
     def create_concat_pangolin(self) -> None:
         """Concatenate nanopore pangolin results"""
-        indir = "{0}/articNcovNanopore_sequenceAnalysisMedaka_pangolinTyping".format(
-            self.indir
-        )
-        concatfile = "{0}/{1}.pangolin.csv".format(self.indir, self.ticket)
-        pango_csvs = glob.glob("{0}/*.pangolin.csv".format(indir))
+        indir = f"{self.indir}/articNcovNanopore_sequenceAnalysisMedaka_pangolinTyping"
+        concatfile = f"{self.indir}/{self.ticket}.pangolin.csv"
+        pango_csvs = glob.glob(f"{indir}/*.pangolin.csv")
 
         header = read_filelines(pango_csvs[0])[0]
         with open(concatfile, "w") as concat:
@@ -166,9 +153,7 @@ class ReportPrinterNanopore:
                 data: list = read_filelines(csv)[1:]
                 for line in data:
                     split_on_comma = line.split(",")
-                    barcode = self.extract_barcode_from_pangolin_csv(
-                        line=split_on_comma[0]
-                    )
+                    barcode = self.extract_barcode_from_pangolin_csv(line=split_on_comma[0])
                     split_on_comma[0] = self.barcode_to_sampleid[barcode]
                     concatenated_line = ""
                     for section in split_on_comma:
@@ -178,9 +163,9 @@ class ReportPrinterNanopore:
 
     def create_concat_pangolin_fohm(self, result: dict) -> None:
         """Prints concatenated pangolin csv for samples passing QC"""
-        concatenated_pangolin = "{0}/{1}.pangolin.csv".format(self.indir, self.ticket)
-        pango_fohm = "{0}/{1}_{2}_pangolin_classification_format4.txt".format(
-            self.indir, self.ticket, str(date.today())
+        concatenated_pangolin = f"{self.indir}/{self.ticket}.pangolin.csv"
+        pango_fohm = (
+            f"{self.indir}/{self.ticket}_{date.today()}_pangolin_classification_format4.txt"
         )
         with open(concatenated_pangolin) as f:
             lines = f.readlines()

--- a/mutant/modules/delivery.py
+++ b/mutant/modules/delivery.py
@@ -1,8 +1,5 @@
 """ This class modifies existing files to fit the Clinical Genomics infrastructure.
     Specifically it acts on the sarscov2 pipeline.
-
-    By: Isak Sylvin & Tanja Normark
-
 """
 
 import glob
@@ -88,19 +85,13 @@ class DeliverySC2:
 
             # rename makeConsensus
             if self.nanopore:
-                consensus_path = "{0}/articNcovNanopore_sequenceAnalysisMedaka_articMinIONMedaka".format(
-                    self.indir
-                )
-                consensus_files = "{0}/{1}.consensus.fasta".format(
-                    consensus_path, illumina_to_nanopore_base[base_sample]
-                )
+                consensus_path = f"{self.indir}/articNcovNanopore_sequenceAnalysisMedaka_articMinIONMedaka"
+                consensus_files = f"{consensus_path}/{illumina_to_nanopore_base[base_sample]}.consensus.fasta"
             else:
-                consensus_path = (
-                    "{0}/ncovIllumina_sequenceAnalysis_makeConsensus".format(self.indir)
-                )
-                consensus_files = "{0}/{1}.*.fa".format(consensus_path, base_sample)
+                consensus_path = f"{self.indir}/ncovIllumina_sequenceAnalysis_makeConsensus"
+                consensus_files = f"{consensus_path}/{base_sample}.*.fa"
             for item in glob.glob(consensus_files):
-                newpath = "{0}/{1}.consensus.fasta".format(consensus_path, base_sample)
+                newpath = f"{consensus_path}/{base_sample}.consensus.fasta"
                 try:
                     with open(item, "r") as old_consensus_io:
                         with open(newpath, "w") as new_consensus_io:
@@ -114,19 +105,13 @@ class DeliverySC2:
 
             # rename typeVariants
             if self.nanopore:
-                vcf_path = "{0}/articNcovNanopore_Genotyping_typeVariants/vcf".format(
-                    self.indir
-                )
-                vcf_files = "{0}/{1}.csq.vcf".format(
-                    vcf_path, illumina_to_nanopore_base[base_sample]
-                )
+                vcf_path = f"{self.indir}/articNcovNanopore_Genotyping_typeVariants/vcf"
+                vcf_files = f"{vcf_path}/{illumina_to_nanopore_base[base_sample]}.csq.vcf"
             else:
-                vcf_path = "{0}/ncovIllumina_Genotyping_typeVariants/vcf".format(
-                    self.indir
-                )
-                vcf_files = "{0}/{1}.csq.vcf".format(vcf_path, base_sample)
+                vcf_path = f"{self.indir}/ncovIllumina_Genotyping_typeVariants/vcf"
+                vcf_files = f"{vcf_path}/{base_sample}.csq.vcf"
             for item in glob.glob(vcf_files):
-                newpath = "{0}/{1}.vcf".format(vcf_path, base_sample)
+                newpath = f"{vcf_path}/{base_sample}.vcf"
                 try:
                     os.symlink(item, newpath)
                 except Exception as e:
@@ -137,40 +122,32 @@ class DeliverySC2:
         # rename multiqc
         if self.nanopore:
             hit = glob.glob(
-                "{}/QCStats/articNcovNanopore_sequenceAnalysisMedaka_multiqcNanopore/*_multiqc.html".format(
-                    self.indir
-                )
+                f"{self.indir}/QCStats/articNcovNanopore_sequenceAnalysisMedaka_multiqcNanopore/*_multiqc.html"
             )
         else:
             hit = glob.glob(
-                "{}/QCStats/ncovIllumina_sequenceAnalysis_multiqc/*_multiqc.html".format(
-                    self.indir
-                )
+                f"{self.indir}/QCStats/ncovIllumina_sequenceAnalysis_multiqc/*_multiqc.html"
             )
         if len(hit) == 1:
             hit = hit[0]
             try:
-                os.symlink(hit, "{}/{}_multiqc.html".format(self.indir, self.ticket))
+                os.symlink(hit, f"{self.indir}/{self.ticket}_multiqc.html")
             except Exception as e:
                 pass
 
         # rename multiqc json
         if self.nanopore:
             hit = glob.glob(
-                "{}/QCStats/articNcovNanopore_sequenceAnalysisMedaka_multiqcNanopore/*_multiqc_data/multiqc_data.json".format(
-                    self.indir
-                )
+                f"{self.indir}/QCStats/articNcovNanopore_sequenceAnalysisMedaka_multiqcNanopore/*_multiqc_data/multiqc_data.json"
             )
         else:
             hit = glob.glob(
-                "{}/QCStats/ncovIllumina_sequenceAnalysis_multiqc/*_multiqc_data/multiqc_data.json".format(
-                    self.indir
-                )
+                f"{self.indir}/QCStats/ncovIllumina_sequenceAnalysis_multiqc/*_multiqc_data/multiqc_data.json"
             )
         if len(hit) == 1:
             hit = hit[0]
             try:
-                os.symlink(hit, "{}/{}_multiqc.json".format(self.indir, self.ticket))
+                os.symlink(hit, f"{self.indir}/{self.ticket}_multiqc.json")
             except Exception as e:
                 pass
 
@@ -180,10 +157,10 @@ class DeliverySC2:
             ".variant_summary.csv",
         ]
         for thing in core_suffix:
-            hit = glob.glob("{0}/*{1}".format(self.indir, thing))
+            hit = glob.glob(f"{self.indir}/*{thing}")
             if len(hit) == 1:
                 hit = hit[0]
                 try:
-                    os.symlink(hit, "{0}/{1}{2}".format(self.indir, self.ticket, thing))
+                    os.symlink(hit, f"{self.indir}/{self.ticket}{thing}")
                 except Exception as e:
                     pass

--- a/mutant/modules/generic_parser.py
+++ b/mutant/modules/generic_parser.py
@@ -42,9 +42,7 @@ def get_json(config) -> dict:
             with open(config) as json_file:
                 data = json.load(json_file)
         except Exception as e:
-            click.echo(
-                f"Unable to read provided json file: {config}. Exiting.."
-            )
+            click.echo(f"Unable to read provided json file: {config}. Exiting..")
             click.echo(e)
             sys.exit(-1)
     else:

--- a/mutant/modules/generic_parser.py
+++ b/mutant/modules/generic_parser.py
@@ -71,7 +71,7 @@ def read_filelines(infile) -> list:
         with open(infile, "r") as f:
             contents = f.readlines()
     except Exception as e:
-        click.echo(f"Unable to read file: {infile}. Exiting..".format)
+        click.echo(f"Unable to read file: {infile}. Exiting..")
         click.echo(e)
         sys.exit(-1)
     return contents

--- a/mutant/modules/generic_parser.py
+++ b/mutant/modules/generic_parser.py
@@ -43,12 +43,12 @@ def get_json(config) -> dict:
                 data = json.load(json_file)
         except Exception as e:
             click.echo(
-                "Unable to read provided json file: {}. Exiting..".format(config)
+                f"Unable to read provided json file: {config}. Exiting.."
             )
             click.echo(e)
             sys.exit(-1)
     else:
-        click.echo("Could not find supplied config: {}. Exiting..".format(config))
+        click.echo(f"Could not find supplied config: {config}. Exiting..")
         sys.exit(-1)
     return data
 
@@ -73,7 +73,7 @@ def read_filelines(infile) -> list:
         with open(infile, "r") as f:
             contents = f.readlines()
     except Exception as e:
-        click.echo("Unable to read file: {}. Exiting..".format(infile))
+        click.echo(f"Unable to read file: {infile}. Exiting..".format)
         click.echo(e)
         sys.exit(-1)
     return contents

--- a/mutant/modules/generic_reporter.py
+++ b/mutant/modules/generic_reporter.py
@@ -53,7 +53,7 @@ class GenericReporter:
     def create_concat_consensus(self, target_files: str) -> None:
         """Concatenate consensus files"""
 
-        concat_consensus = "{0}/{1}.consensus.fa".format(self.indir, self.ticket)
+        concat_consensus = f"{self.indir}/{self.ticket}.consensus.fa"
         concat = open(concat_consensus, "w+")
         for item in glob.glob(target_files):
             single = open(item, "r")
@@ -61,106 +61,113 @@ class GenericReporter:
             concat.write("\n")
         concat.close()
 
-    def create_deliveryfile(self, fastq_dir: str) -> None:
+    def create_delivery_metrics(self, fastq_dir: str) -> None:
         """Create deliverables file"""
 
-        deliv = {"files": []}
-        delivfile = "{}/{}_deliverables.yaml".format(self.indir, self.case)
+        deliverables = {"files": []}
+        deliverables_file = f"{self.indir}/{self.case}_deliverables.yaml"
 
-        ## Per Case
         # Instrument properties
-        deliv["files"].append(
+        deliverables["files"].append(
             {
                 "format": "txt",
                 "id": self.case,
-                "path": "{}/instrument.properties".format(self.indir),
+                "path": f"{self.indir}/instrument.properties",
                 "path_index": "~",
                 "step": "report",
                 "tag": "instrument-properties",
             }
         )
         # KS Report
-        deliv["files"].append(
+        deliverables["files"].append(
             {
                 "format": "csv",
                 "id": self.case,
-                "path": "{}/sars-cov-2_{}_results.csv".format(self.indir, self.ticket),
+                "path": f"{self.indir}/sars-cov-2_{self.ticket}_results.csv",
                 "path_index": "~",
                 "step": "report",
                 "tag": "ks-results",
             }
         )
         # KS Aux report
-        deliv["files"].append(
+        deliverables["files"].append(
             {
                 "format": "csv",
                 "id": self.case,
-                "path": "{}/sars-cov-2_{}_variants.csv".format(self.indir, self.ticket),
+                "path": f"{self.indir}/sars-cov-2_{self.ticket}_variants.csv",
                 "path_index": "~",
                 "step": "report",
                 "tag": "ks-aux-results",
             }
         )
         # Pangolin typing
-        deliv["files"].append(
+        deliverables["files"].append(
             {
                 "format": "csv",
                 "id": self.case,
-                "path": "{}/{}.pangolin.csv".format(self.indir, self.ticket),
+                "path": f"{self.indir}/{self.ticket}.pangolin.csv",
                 "path_index": "~",
                 "step": "report",
                 "tag": "pangolin-typing",
             }
         )
         # Pangolin typing for FOHM (only qcpass files)
-        deliv["files"].append(
+        deliverables["files"].append(
             {
                 "format": "csv",
                 "id": self.case,
-                "path": "{}/{}_{}_pangolin_classification_format4.txt".format(
-                    self.indir, self.ticket, str(date.today())
-                ),
+                "path": f"{self.indir}/{self.ticket}_{date.today()}_pangolin_classification_format4.txt",
                 "path_index": "~",
                 "step": "report",
                 "tag": "pangolin-typing-fohm",
             }
         )
         # Consensus file
-        deliv["files"].append(
+        deliverables["files"].append(
             {
                 "format": "fasta",
                 "id": self.case,
-                "path": "{}/{}.consensus.fa".format(self.indir, self.ticket),
+                "path": f"{self.indir}/{self.ticket}.consensus.fa",
                 "path_index": "~",
                 "step": "analysis",
                 "tag": "consensus",
             }
         )
         # Multiqc report
-        deliv["files"].append(
+        deliverables["files"].append(
             {
                 "format": "html",
                 "id": self.case,
-                "path": "{}/{}_multiqc.html".format(self.indir, self.ticket),
+                "path": f"{self.indir}/{self.ticket}_multiqc.html",
                 "path_index": "~",
                 "step": "report",
                 "tag": "multiqc-html",
             }
         )
         # MultiQC json
-        deliv["files"].append(
+        deliverables["files"].append(
             {
                 "format": "json",
                 "id": self.case,
-                "path": "{}/{}_multiqc.json".format(self.indir, self.ticket),
+                "path": f"{self.indir}/{self.ticket}_multiqc.json",
                 "path_index": "~",
                 "step": "report",
                 "tag": "multiqc-json",
             }
         )
+        deliverables["files"].append(
+            {
+                "format": "csv",
+                "id": self.case,
+                "path": f"{self.indir}/nextclade_summary.csv",
+                "path_index": "~",
+                "step": "report",
+                "tag": "nextclade-summary",
+            }
+        )
         if not self.nanopore:
             # Artic yaml (Vogue) data
-            deliv["files"].append(
+            deliverables["files"].append(
                 {
                     "format": "yaml",
                     "id": self.case,
@@ -171,7 +178,7 @@ class GenericReporter:
                 }
             )
         # Provided CG CASE info from StatusDB
-        deliv["files"].append(
+        deliverables["files"].append(
             {
                 "format": "json",
                 "id": self.case,
@@ -182,7 +189,7 @@ class GenericReporter:
             }
         )
         # Input settings dump
-        deliv["files"].append(
+        deliverables["files"].append(
             {
                 "format": "txt",
                 "id": self.case,
@@ -193,7 +200,7 @@ class GenericReporter:
             }
         )
         # Software versions
-        deliv["files"].append(
+        deliverables["files"].append(
             {
                 "format": "csv",
                 "id": self.case,
@@ -204,23 +211,23 @@ class GenericReporter:
             }
         )
         # Execution log
-        deliv["files"].append(
+        deliverables["files"].append(
             {
                 "format": "txt",
                 "id": self.case,
-                "path": "{}/nextflow.log".format(self.indir),
+                "path": f"{self.indir}/nextflow.log",
                 "path_index": "~",
                 "step": "runinfo",
                 "tag": "logfile",
             }
         )
         # FoHM delivery file
-        deliv["files"].append(
+        deliverables["files"].append(
             {
                 "format": "csv",
                 "id": self.case,
                 "path": os.path.join(
-                    self.indir, "{}_komplettering.csv".format(self.ticket)
+                    self.indir, f"{self.ticket}_komplettering.csv"
                 ),
                 "path_index": "~",
                 "step": "report",
@@ -234,42 +241,36 @@ class GenericReporter:
             sample = record["Customer_ID_sample"]
             region = record["region_code"]
             lab = record["lab_code"]
-            base_sample = "{0}_{1}_{2}".format(region, lab, sample)
+            base_sample = f"{region}_{lab}_{sample}"
             if self.nanopore:
                 # Concat reads forwards
-                deliv["files"].append(
+                deliverables["files"].append(
                     {
                         "format": "fastq",
                         "id": sampleID,
-                        "path": "{0}/{1}/{2}_1.fastq.gz".format(
-                            fastq_dir, sample, base_sample
-                        ),
+                        "path": f"{fastq_dir}/{sample}/{base_sample}_1.fastq.gz",
                         "path_index": "~",
                         "step": "concatination",
                         "tag": "forward-reads",
                     }
                 )
                 # Variants (vcf)
-                deliv["files"].append(
+                deliverables["files"].append(
                     {
                         "format": "vcf",
                         "id": sampleID,
-                        "path": "{}/articNcovNanopore_Genotyping_typeVariants/vcf/{}.vcf".format(
-                            self.indir, base_sample
-                        ),
+                        "path": f"{self.indir}/articNcovNanopore_Genotyping_typeVariants/vcf/{base_sample}.vcf",
                         "path_index": "~",
                         "step": "genotyping",
                         "tag": "vcf-covid",
                     }
                 )
                 # Single-file fasta
-                deliv["files"].append(
+                deliverables["files"].append(
                     {
                         "format": "fasta",
                         "id": sampleID,
-                        "path": "{}/articNcovNanopore_sequenceAnalysisMedaka_articMinIONMedaka/{}.consensus.fasta".format(
-                            self.indir, base_sample
-                        ),
+                        "path": f"{self.indir}/articNcovNanopore_sequenceAnalysisMedaka_articMinIONMedaka/{base_sample}.consensus.fasta",
                         "path_index": "~",
                         "step": "consensus",
                         "tag": "consensus-sample",
@@ -279,52 +280,50 @@ class GenericReporter:
                 if not record["sequencing_qc_pass"]:
                     continue
                 # Concat reads forwards
-                deliv["files"].append(
+                deliverables["files"].append(
                     {
                         "format": "fastq",
                         "id": sampleID,
-                        "path": "{0}/{1}_1.fastq.gz".format(fastq_dir, base_sample),
+                        "path": f"{fastq_dir}/{base_sample}_1.fastq.gz",
                         "path_index": "~",
                         "step": "concatination",
                         "tag": "forward-reads",
                     }
                 )
                 # Concat reads reverse
-                deliv["files"].append(
+                deliverables["files"].append(
                     {
                         "format": "fastq",
                         "id": sampleID,
-                        "path": "{0}/{1}_2.fastq.gz".format(fastq_dir, base_sample),
+                        "path": f"{fastq_dir}/{base_sample}_2.fastq.gz",
                         "path_index": "~",
                         "step": "concatination",
                         "tag": "reverse-reads",
                     }
                 )
                 # Variants (vcf)
-                deliv["files"].append(
+                deliverables["files"].append(
                     {
                         "format": "vcf",
                         "id": sampleID,
-                        "path": "{}/ncovIllumina_Genotyping_typeVariants/vcf/{}.vcf".format(
-                            self.indir, base_sample
-                        ),
+                        "path": f"{self.indir}/ncovIllumina_Genotyping_typeVariants/vcf/{base_sample}.vcf",
                         "path_index": "~",
                         "step": "genotyping",
                         "tag": "vcf-covid",
                     }
                 )
                 # Single-file fasta
-                deliv["files"].append(
+                deliverables["files"].append(
                     {
                         "format": "fasta",
                         "id": sampleID,
-                        "path": "{}/ncovIllumina_sequenceAnalysis_makeConsensus/{}.consensus.fasta".format(
-                            self.indir, base_sample
+                        "path": (
+                            f"{self.indir}/ncovIllumina_sequenceAnalysis_makeConsensus/{base_sample}.consensus.fasta"
                         ),
                         "path_index": "~",
                         "step": "consensus",
                         "tag": "consensus-sample",
                     }
                 )
-        with open(delivfile, "w") as out:
-            yaml.dump(deliv, out)
+        with open(deliverables_file, "w") as out:
+            yaml.dump(deliverables, out)

--- a/mutant/standalone/deploy_hasta_update.sh
+++ b/mutant/standalone/deploy_hasta_update.sh
@@ -31,5 +31,7 @@ git submodule update
 #git submodule foreach 'git fetch origin; git checkout $(git rev-parse --abbrev-ref HEAD); git reset --hard origin/$(git rev-parse --abbrev-ref HEAD); git submodule update --recursive; git clean -dfx'
 
 # Pull latest image
-singularity pull --force /home/proj/${INSTANCE}/mutant/MUTANT/mutant/externals/gms-artic/artic-ncov2019-illumina.sif docker://genomicmedicinesweden/gms-artic-illumina:latest
+singularity pull --force /home/proj/${INSTANCE}/mutant/MUTANT/mutant/externals/gms-artic/artic-ncov2019-illumina.sif docker://genomicmedicinesweden/gms-artic-illumina:0c599b9
+singularity pull --force /home/proj/${INSTANCE}/mutant/MUTANT/mutant/externals/gms-artic/artic-ncov2019-pangolin.sif docker://genomicmedicinesweden/gms-artic-pangolin:latest
 chmod u=rwx,g=rx,o=rx mutant/externals/gms-artic/artic-ncov2019-illumina.sif
+chmod u=rwx,g=rx,o=rx mutant/externals/gms-artic/artic-ncov2019-pangolin.sif


### PR DESCRIPTION
### The purpose of the code changes are as follows:
-  Add a nextclade summary file in the results folder
- Update gms-artic version and container version

### How to prepare for test
- [x] symlink fast files for case maturejay to stage housekeeper
- [x] ssh to hasta.scilifelab.se
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_hermes -t hermes -b [THIS-BRANCH-NAME]`
- [x] `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b master -a`
- [x] deploy MUTANT branch nextclade_summaryfile with changes to gms-artic and updated singularity images
  - [x] `cd MUTANT`
  - [x] `bash mutant/standalone/deploy_hasta_update.sh stage <MUTANT_branch>`
  - [x] `cd mutant/externals/gms-artic` 
  - [x] `git checkout update_nextclade`
  - [x] `singularity pull --force /home/proj/stage/mutant/MUTANT/mutant/externals/gms-artic/artic-ncov2019-illumina.sif docker://genomicmedicinesweden/gms-artic-illumina-stage:latest`
  - [x] `singularity pull --force /home/proj/stage/mutant/MUTANT/mutant/externals/gms-artic/artic-ncov2019-nanopore.sif docker://genomicmedicinesweden/gms-artic-nanopore-stage:latest`
 
### How to test:
Run in a tmux screen or similar if testing on a large dataset.

**Test with cg**:
- `us`
- `cg workflow mutant start maturejay`

### Expected test outcome
- [x] Check that the command finish without error and that the nextclade file is added to housekeeper
- [x] Take a screenshot and attach or copy/paste the output.

### Review:
- [ ] Code reviewed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
