### PR TITLE
Update the iVarFrequency threshold

### DIFF
--- a/mutant/config/hasta/default_config.json
+++ b/mutant/config/hasta/default_config.json
@@ -93,13 +93,13 @@ if ( params.illumina ) {
         // Mpileup depth for ivar (although undocumented in mpileup, setting to zero removes limit)
         mpileupDepth = 100000
         // iVar frequency threshold for consensus variant (ivar consensus: -t)
-        ivarFreqThreshold = 0.75
+        varFreqThreshold = 0.75
         // Minimum coverage depth to call variant (ivar consensus: -m; ivar variants -m)
-        ivarMinDepth = 10
+        varMinDepth = 10
         // iVar frequency threshold to call variant (ivar variants: -t )
-        ivarMinFreqThreshold = 0.03
+        varMinFreqThreshold = 0.03
         // iVar minimum mapQ to call variant (ivar variants: -q)
-        ivarMinVariantQuality = 20
+        varMinVariantQuality = 20
         // Typing frequency threshold to call aa consequences of variant. Set to ivarFreqThreshold for consistency with consensus
         csqAfThreshold = 0.75
         // Minimum coverage depth to call aa consequences of variant. Set to ivarMinDepth for consistency with consensus

--- a/mutant/config/hasta/default_config.json
+++ b/mutant/config/hasta/default_config.json
@@ -97,7 +97,7 @@ if ( params.illumina ) {
         // Minimum coverage depth to call variant (ivar consensus: -m; ivar variants -m)
         ivarMinDepth = 10
         // iVar frequency threshold to call variant (ivar variants: -t )
-        ivarMinFreqThreshold = 0.25
+        ivarMinFreqThreshold = 0.03
         // iVar minimum mapQ to call variant (ivar variants: -q)
         ivarMinVariantQuality = 20
         // Typing frequency threshold to call aa consequences of variant. Set to ivarFreqThreshold for consistency with consensus


### PR DESCRIPTION
### The purpose of the code changes are as follows:
-  This PR changes the config file to update the iVarFrequency threshold from 0.25 to 0.03

### Preparations:

**How to prepare mutant for test**:
* `cd MUTANT`
* `bash mutant/standalone/deploy_hasta_update.sh stage <MUTANT_branch>`

**How to prepare cg for test**:
- `us`
- Paxa and update cg:
  - `paxa -u <user> -s hasta -r cg-stage`
  - `bash update-cg-stage.sh master`
- If needed, paxa and update servers:
  - `paxa -u <user> -s hasta -r servers-stage`
  - `bash update-servers-stage.sh <master/branch>`
  
### How to test:
Run in a tmux screen or similar if testing on a large dataset.

**Test with cg**:
- `us`
- `cg workflow mutant start maturejay`

### Expected outcome:
- [ ] Produced files contain expected values

### Review:
- [ ] Code reviewed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
