### PR TITLE
Store vcfs on a case level

### DIFF
--- a/mutant/modules/generic_reporter.py
+++ b/mutant/modules/generic_reporter.py
@@ -226,9 +226,7 @@ class GenericReporter:
             {
                 "format": "csv",
                 "id": self.case,
-                "path": os.path.join(
-                    self.indir, f"{self.ticket}_komplettering.csv"
-                ),
+                "path": os.path.join(self.indir, f"{self.ticket}_komplettering.csv"),
                 "path_index": "~",
                 "step": "report",
                 "tag": "SARS-CoV-2-info",
@@ -258,7 +256,7 @@ class GenericReporter:
                 deliverables["files"].append(
                     {
                         "format": "vcf",
-                        "id": sampleID,
+                        "id": self.case,
                         "path": f"{self.indir}/articNcovNanopore_Genotyping_typeVariants/vcf/{base_sample}.vcf",
                         "path_index": "~",
                         "step": "genotyping",
@@ -305,7 +303,7 @@ class GenericReporter:
                 deliverables["files"].append(
                     {
                         "format": "vcf",
-                        "id": sampleID,
+                        "id": self.case,
                         "path": f"{self.indir}/ncovIllumina_Genotyping_typeVariants/vcf/{base_sample}.vcf",
                         "path_index": "~",
                         "step": "genotyping",


### PR DESCRIPTION
### The purpose of the code changes are as follows:

-  Change the id to be case so that all of the vcfs are delivered to the case folder instead of in each sample folder.

### Preparations:

**How to prepare mutant for test**:
* `cd MUTANT`
* `bash mutant/standalone/deploy_hasta_update.sh stage <MUTANT_branch>`

**How to prepare cg for test**:
- `us`
- Paxa and update cg:
  - `paxa -u <user> -s hasta -r cg-stage`
  - `bash update-cg-stage.sh master`
- If needed, paxa and update servers:
  - `paxa -u <user> -s hasta -r servers-stage`
  - `bash update-servers-stage.sh <master/branch>`
  
### How to test:
Run in a tmux screen or similar if testing on a large dataset.

**Test with cg**:
- `us`
- `cg workflow mutant start maturejay`

### Expected outcome:
- [ ] Produced files contain expected values

### Review:
- [ ] Code reviewed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
