### PR TITLE
fix(remove fastq storing on deliverables)

### DIFF
--- a/mutant/modules/generic_reporter.py
+++ b/mutant/modules/generic_reporter.py
@@ -226,9 +226,7 @@ class GenericReporter:
             {
                 "format": "csv",
                 "id": self.case,
-                "path": os.path.join(
-                    self.indir, f"{self.ticket}_komplettering.csv"
-                ),
+                "path": os.path.join(self.indir, f"{self.ticket}_komplettering.csv"),
                 "path_index": "~",
                 "step": "report",
                 "tag": "SARS-CoV-2-info",
@@ -279,28 +277,6 @@ class GenericReporter:
             else:
                 if not record["sequencing_qc_pass"]:
                     continue
-                # Concat reads forwards
-                deliverables["files"].append(
-                    {
-                        "format": "fastq",
-                        "id": sampleID,
-                        "path": f"{fastq_dir}/{base_sample}_1.fastq.gz",
-                        "path_index": "~",
-                        "step": "concatination",
-                        "tag": "forward-reads",
-                    }
-                )
-                # Concat reads reverse
-                deliverables["files"].append(
-                    {
-                        "format": "fastq",
-                        "id": sampleID,
-                        "path": f"{fastq_dir}/{base_sample}_2.fastq.gz",
-                        "path_index": "~",
-                        "step": "concatination",
-                        "tag": "reverse-reads",
-                    }
-                )
                 # Variants (vcf)
                 deliverables["files"].append(
                     {


### PR DESCRIPTION
### The purpose of the code changes are as follows:
-  THING

### Preparations:

**How to prepare mutant for test**:
* `cd MUTANT`
* `bash mutant/standalone/deploy_hasta_update.sh stage <MUTANT_branch>`

**How to prepare cg for test**:
- `us`
- Paxa and update cg:
  - `paxa -u <user> -s hasta -r cg-stage`
  - `bash update-cg-stage.sh master`
- If needed, paxa and update servers:
  - `paxa -u <user> -s hasta -r servers-stage`
  - `bash update-servers-stage.sh <master/branch>`
  
### How to test:
Run in a tmux screen or similar if testing on a large dataset.

**Test with cg**:
- `us`
- `cg workflow mutant start maturejay`

### Expected outcome:
- [ ] Produced files contain expected values

### Review:
- [ ] Code reviewed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
