### PR TITLE
Lower qc threshold

### DIFF
--- a/mutant/constants/artic.py
+++ b/mutant/constants/artic.py
@@ -75,3 +75,7 @@ NEXTCLADE_HEADER = [
     "immune_escape",
     "ace2_binding",
 ]
+
+
+# Cut-off threshold for uploading to FOHM
+PCT_10X_THRESHOLD = 67

--- a/mutant/modules/artic_illumina/parser.py
+++ b/mutant/modules/artic_illumina/parser.py
@@ -147,7 +147,7 @@ def get_artic_results(indir) -> dict:
         next(content)
         for line in content:
             sample = line[0].split("_")[-1]
-            if float(line[2]) >= 67:
+            if float(line[2]) >= MULTIQC_TO_VOGUE["multiqc_picard_wgsmetrics"]["fields"]["PCT_10X"]:
                 qc_flag = "TRUE"
             else:
                 qc_flag = "FALSE"

--- a/mutant/modules/artic_illumina/parser.py
+++ b/mutant/modules/artic_illumina/parser.py
@@ -10,7 +10,7 @@ import re
 from pathlib import Path
 from typing import Dict, List
 from mutant import WD
-from mutant.constants.artic import MULTIQC_TO_VOGUE, NEXTCLADE_HEADER
+from mutant.constants.artic import MULTIQC_TO_VOGUE, NEXTCLADE_HEADER, PCT_10X_THRESHOLD
 from mutant.modules.generic_parser import append_dict, parse_classifications
 
 
@@ -147,7 +147,7 @@ def get_artic_results(indir) -> dict:
         next(content)
         for line in content:
             sample = line[0].split("_")[-1]
-            if float(line[2]) >= MULTIQC_TO_VOGUE["multiqc_picard_wgsmetrics"]["fields"]["PCT_10X"]:
+            if float(line[2]) >= PCT_10X_THRESHOLD:
                 qc_flag = "TRUE"
             else:
                 qc_flag = "FALSE"

--- a/mutant/modules/artic_illumina/parser.py
+++ b/mutant/modules/artic_illumina/parser.py
@@ -147,7 +147,7 @@ def get_artic_results(indir) -> dict:
         next(content)
         for line in content:
             sample = line[0].split("_")[-1]
-            if float(line[2]) >= 90:
+            if float(line[2]) >= 67:
                 qc_flag = "TRUE"
             else:
                 qc_flag = "FALSE"


### PR DESCRIPTION
### The purpose of the code changes are as follows:
-  From email discussion:

`I årets avtal för SARS-CoV-2 sekvenseringen anger Folkhälsomyndigheten att max antal N för att godkänna konsensus-sekvens är ≤10000 (dvs 2/3 av genomet), jag tror vi har en högre cutoff idag (95% av genomet?). Tacksam pipeline kan justeras innan kommande sekvensering (om tre veckor).`

### Preparations:

**How to prepare mutant for test**:
* `cd MUTANT`
* `bash mutant/standalone/deploy_hasta_update.sh stage <MUTANT_branch>`

**How to prepare cg for test**:
- `us`
- Paxa and update cg:
  - `paxa -u <user> -s hasta -r cg-stage`
  - `bash update-cg-stage.sh master`
- If needed, paxa and update servers:
  - `paxa -u <user> -s hasta -r servers-stage`
  - `bash update-servers-stage.sh <master/branch>`
  
### How to test:
Run in a tmux screen or similar if testing on a large dataset.

**Test with cg**:
- `us`
- `cg workflow mutant start maturejay`


### Expected outcome:
- [x] Produced files contain expected values
<img width="1324" alt="Screenshot 2025-01-15 at 11 23 17" src="https://github.com/user-attachments/assets/8d560bc5-de5c-40b9-a98f-5dda001f6fd4" />



### Review:
- [ ] Code reviewed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
